### PR TITLE
feat: localize date formatting

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,14 +34,17 @@ const COL = {
 
 const $ = s => document.querySelector(s);
 
-function fmtDate(v){
+function fmtDate(v, locale = (typeof navigator !== 'undefined' && navigator.language) ? navigator.language : 'es-MX'){
   if(!v) return '';
   const d = new Date(v);
   if(isNaN(d)) return String(v);
-  return d.toLocaleString('en-US',{
+  return d.toLocaleString(locale,{
     year:'numeric', month:'2-digit', day:'2-digit',
-    hour:'2-digit', minute:'2-digit', hour12:true
+    hour:'2-digit', minute:'2-digit'
   }).replace(',', '');
+}
+if(typeof module !== 'undefined' && module.exports){
+  module.exports = { fmtDate };
 }
 function badgeForStatus(s){
   if(!s) return '';
@@ -197,4 +200,6 @@ async function main(){
     try{ await navigator.serviceWorker.register('./sw.js'); }catch{}
   }
 }
-main();
+if (typeof document !== 'undefined') {
+  main();
+}

--- a/fmtDate.test.js
+++ b/fmtDate.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const { fmtDate } = require('./app.js');
+
+const sample = '2024-06-09T15:30:00';
+
+assert.strictEqual(fmtDate(sample, 'en-US'), '06/09/2024 03:30 PM');
+assert.strictEqual(fmtDate(sample, 'es-MX'), '09/06/2024 03:30 p.m.');
+assert.strictEqual(fmtDate(sample, 'de-DE'), '09.06.2024 15:30');
+
+console.log('All fmtDate locale tests passed.');


### PR DESCRIPTION
## Summary
- respect user's locale when formatting dates
- export fmtDate for node and skip main() when no DOM
- test fmtDate with multiple locales

## Testing
- `node fmtDate.test.js`
- `node -e "const {fmtDate}=require('./app.js'); console.log('en-US', fmtDate('2024-06-09T15:30:00','en-US')); console.log('es-MX', fmtDate('2024-06-09T15:30:00','es-MX')); console.log('de-DE', fmtDate('2024-06-09T15:30:00','de-DE'));"`


------
https://chatgpt.com/codex/tasks/task_e_68afc054bc38832b841ebfda0507e1bd