### PR TITLE
Add web app manifest and cache it

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Seguimiento de Cargas",
+  "short_name": "Cargas",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0F2C5C",
+  "icons": [
+    {
+      "src": "assets/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -7,6 +7,7 @@ const ASSETS = [
   './styles.css',
   './app.js',
   './assets/logo.png',
+  './manifest.json',
   // agrega aquí otros archivos si los tienes (manifest, íconos, etc.)
 ];
 


### PR DESCRIPTION
## Summary
- add web app manifest with basic PWA settings
- cache manifest via service worker

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1cac1f660832bb97c033bc1a0a326