### PR TITLE
Refactor fmtDate to use explicit locale date and time

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,10 +61,13 @@ function fmtDate(v, locale = (typeof navigator !== 'undefined' && navigator.lang
   }
 
   if(isNaN(d)) return String(v);
-  return d.toLocaleString(locale,{
-    year:'numeric', month:'2-digit', day:'2-digit',
+  const dateStr = d.toLocaleDateString(locale, {
+    year:'numeric', month:'2-digit', day:'2-digit'
+  });
+  const timeStr = d.toLocaleTimeString(locale, {
     hour:'2-digit', minute:'2-digit'
-  }).replace(',', '');
+  });
+  return `${dateStr} ${timeStr}`;
 }
 if(typeof module !== 'undefined' && module.exports){
   module.exports = { fmtDate };


### PR DESCRIPTION
## Summary
- Format dates by combining `toLocaleDateString` and `toLocaleTimeString` instead of stripping commas from `toLocaleString`

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef7024c4832ba86b3c26c8acd9ea