### PR TITLE
Handle invalid JSON responses in update flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,7 +162,17 @@ async function updateDelivered(trip){
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ action:'delivered', trip })
     });
-    const json = await res.json().catch(()=> ({}));
+    let json;
+    try{
+      const ct = res.headers.get('content-type') || '';
+      if(!ct.includes('application/json')){
+        throw new Error('Missing application/json header');
+      }
+      json = await res.json();
+    }catch(err){
+      if(err.message === 'Missing application/json header') throw err;
+      throw new Error('Invalid JSON');
+    }
     if(!res.ok || json.error){
       throw new Error(json.error || `HTTP ${res.status}`);
     }
@@ -182,7 +192,17 @@ async function addRecord(data){
       headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ action:'add', ...data })
     });
-    const json = await res.json().catch(()=> ({}));
+    let json;
+    try{
+      const ct = res.headers.get('content-type') || '';
+      if(!ct.includes('application/json')){
+        throw new Error('Missing application/json header');
+      }
+      json = await res.json();
+    }catch(err){
+      if(err.message === 'Missing application/json header') throw err;
+      throw new Error('Invalid JSON');
+    }
     if(!res.ok || json.error){
       throw new Error(json.error || `HTTP ${res.status}`);
     }


### PR DESCRIPTION
## Summary
- Validate Content-Type and JSON parsing in updateDelivered
- Apply same JSON validation for addRecord submissions

## Testing
- `node fmtDate.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b1ef84365c832b98295f5127bdfbba