### PR TITLE
fix: restore manifest background to original blue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "start_url": "./index.html",
   "scope": "./",
   "display": "standalone",
-  "background_color": "#ffffff",
+  "background_color": "#0B2341",
   "theme_color": "#0F2C5C",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- ensure PWA launch uses the original dark blue background color

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b206586f28832bbe445413d62df07b