### PR TITLE
fix: update manifest paths for GitHub Pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,19 @@
 {
   "name": "Seguimiento de Cargas",
   "short_name": "Cargas",
-  "start_url": "./index.html",
-  "scope": "./",
+  "start_url": "/seguimiento_cargas_pwa/",
+  "scope": "/seguimiento_cargas_pwa/",
   "display": "standalone",
   "background_color": "#082341",
   "theme_color": "#0F2C5C",
   "icons": [
     {
-      "src": "assets/icon-192.png",
+      "src": "/seguimiento_cargas_pwa/assets/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "assets/icon-512.png",
+      "src": "/seguimiento_cargas_pwa/assets/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary
- update start_url and scope for GitHub Pages deployment
- use absolute icon paths in manifest.json

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b234b956c8832b88f233cebbce71cd