### PR TITLE
Add daily loads sidebar menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -360,6 +360,26 @@ function renderRows(rows){
   }
 }
 
+function renderDaily(rows){
+  const today = new Date();
+  today.setUTCHours(0,0,0,0);
+  const tomorrow = new Date(today);
+  tomorrow.setUTCDate(today.getUTCDate() + 1);
+  const allowed = ['in transit mx','live','drop','loading','mty yard','qro yard'];
+  const filtered = rows.filter(r=>{
+    const status = String(r[COL.estatus]||'').trim().toLowerCase();
+    if(!allowed.includes(status)) return false;
+    const cita = parseDate(r[COL.citaCarga]);
+    if(!cita) return false;
+    return cita >= today && cita < tomorrow;
+  });
+  $('#statusFilter').value = '';
+  $('#searchBox').value = '';
+  $('#startDate').value = '';
+  $('#endDate').value = '';
+  renderRows(filtered);
+}
+
 async function main(){
   cache = await fetchData();
   renderRows(cache);
@@ -400,6 +420,7 @@ async function main(){
       $('#addModal').classList.remove('show');
     }
   });
+  $('#dailyMenu').addEventListener('click', ()=>renderDaily(cache));
 
   $('#loadsTable').addEventListener('click', async ev=>{
     const btn = ev.target.closest('button[data-act]'); if(!btn) return;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
     <h1>Seguimiento de Cargas</h1>
   </header>
 
+  <!-- Menú lateral -->
+  <nav class="side-menu">
+    <button id="dailyMenu" class="side-btn">📅 Cargas Diarias</button>
+  </nav>
+
   <main class="container">
     <section class="controls">
       <label for="statusFilter">Filtro estatus:</label>

--- a/styles.css
+++ b/styles.css
@@ -34,12 +34,13 @@ html,body{
   color: var(--text);
   padding: 14px 20px;
   box-shadow: inset 0 0 1px rgba(255,255,255,.08);
+  margin-left:180px;
 }
 .app-logo{ height:40px; margin-right:8px; }
 
 /* ====== Contenedor ====== */
 .container {
-  margin: 22px 0;
+  margin: 22px 0 22px 180px;
 }
 
 /* ====== Controles ====== */
@@ -144,3 +145,16 @@ html,body{
 .modal-content label{ display:flex; flex-direction:column; gap:4px; margin-bottom:10px; }
 .modal-content input{ background:#0b1f3d; border:1px solid #1f3e73; color:var(--text); border-radius:10px; padding:8px; }
 .modal-actions{ display:flex; justify-content:flex-end; gap:10px; margin-top:12px; }
+
+/* ====== Menú lateral ====== */
+.side-menu{
+  position:fixed; top:0; left:0; bottom:0;
+  width:160px; background:var(--panel);
+  padding-top:20px; display:flex; flex-direction:column;
+}
+.side-btn{
+  background:transparent; border:0; color:var(--text);
+  padding:12px 16px; text-align:left; cursor:pointer;
+  font-weight:600;
+}
+.side-btn:hover{ background:var(--panel-2); }


### PR DESCRIPTION
## Summary
- add left sidebar with "Cargas Diarias" button
- filter loads by today's date and active statuses in daily view
- style layout to accommodate sidebar

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b27e639088832bb2287fedb58d6bd4