### PR TITLE
Fix timezone offsets in date handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,8 @@ function parseDate(v){
     const [datePart, timePart] = v.split(' ');
     const [day, month, year] = datePart.split('/').map(n => parseInt(n, 10));
     const [hour, minute, second] = timePart.split(':').map(n => parseInt(n, 10));
-    return new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+    // Interpretamos la fecha como hora local, no UTC, para evitar desfases
+    return new Date(year, month - 1, day, hour, minute, second);
   }
   const d = new Date(v);
   return isNaN(d) ? null : d;
@@ -67,7 +68,8 @@ function fmtDate(v, locale = (typeof navigator !== 'undefined' && navigator.lang
     const [datePart, timePart] = v.split(' ');
     const [day, month, year] = datePart.split('/').map(n => parseInt(n, 10));
     const [hour, minute, second] = timePart.split(':').map(n => parseInt(n, 10));
-    d = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+    // Crear fecha en zona local para mostrarla sin corrimientos de horario
+    d = new Date(year, month - 1, day, hour, minute, second);
   }else{
     d = new Date(v);
   }
@@ -251,10 +253,15 @@ function renderRows(rows){
   const tb = $('#loadsTable tbody');
   tb.innerHTML = '';
 
-  const startDate = startVal ? new Date(startVal) : null;
-  if(startDate) startDate.setUTCHours(0,0,0,0);
-  const endDate = endVal ? new Date(endVal) : null;
-  if(endDate) endDate.setUTCHours(23,59,59,999);
+  // Interpretar fechas de filtro como locales para no desplazar horarios
+  const startDate = startVal ? (()=>{
+    const [y,m,d] = startVal.split('-').map(Number);
+    return new Date(y, m-1, d, 0,0,0,0);
+  })() : null;
+  const endDate = endVal ? (()=>{
+    const [y,m,d] = endVal.split('-').map(Number);
+    return new Date(y, m-1, d, 23,59,59,999);
+  })() : null;
 
   const filtered = rows.filter(r=>{
     const s = String(r[COL.estatus]||'');

--- a/fmtDate.test.js
+++ b/fmtDate.test.js
@@ -13,4 +13,10 @@ assert.strictEqual(fmtDate(customSample, 'en-US'), '06/09/2024 03:30 PM');
 assert.strictEqual(fmtDate(customSample, 'es-MX'), '09/06/2024 03:30 p.m.');
 assert.strictEqual(fmtDate(customSample, 'de-DE'), '09.06.2024 15:30');
 
+// Ensure custom format keeps local time without offset
+const diffSample = '30/08/2025 08:00:00';
+assert.strictEqual(fmtDate(diffSample, 'en-US'), '08/30/2025 08:00 AM');
+assert.strictEqual(fmtDate(diffSample, 'es-MX'), '30/08/2025 08:00 a.m.');
+assert.strictEqual(fmtDate(diffSample, 'de-DE'), '30.08.2025 08:00');
+
 console.log('All fmtDate tests passed.');


### PR DESCRIPTION
## Summary
- Treat custom date strings as local time in parseDate and fmtDate to avoid 6-hour shifts
- Parse start and end date filters using local timezone boundaries
- Add tests ensuring date formatting preserves local time

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)
- ✅ `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b285614558832ba338bc16d7b06d0f