### PR TITLE
Add General view to side menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,6 +393,14 @@ function renderRows(rows, hiddenCols=[]){
   }
 }
 
+function renderGeneral(rows){
+  $('#statusFilter').value = '';
+  $('#searchBox').value = '';
+  $('#startDate').value = '';
+  $('#endDate').value = '';
+  renderRows(rows);
+}
+
 function renderDaily(rows){
   const today = new Date();
   today.setUTCHours(0,0,0,0);
@@ -457,6 +465,7 @@ async function main(){
       $('#addModal').classList.remove('show');
     }
   });
+  $('#generalMenu').addEventListener('click', ()=>renderGeneral(cache));
   $('#dailyMenu').addEventListener('click', ()=>renderDaily(cache));
 
   $('#loadsTable').addEventListener('click', async ev=>{

--- a/index.html
+++ b/index.html
@@ -14,10 +14,11 @@
     <h1>Seguimiento de Cargas</h1>
   </header>
 
-  <!-- Menú lateral -->
-  <nav class="side-menu">
+    <!-- Menú lateral -->
+    <nav class="side-menu">
+    <button id="generalMenu" class="side-btn">📋 General</button>
     <button id="dailyMenu" class="side-btn">📅 Cargas Diarias</button>
-  </nav>
+    </nav>
 
   <main class="container">
     <section class="controls">


### PR DESCRIPTION
## Summary
- Add **General** option to the side navigation menu
- Create `renderGeneral` helper to reset filters and show all rows
- Wire up new menu button to render default view

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28bd3a40c832b91de4026307226bb