### PR TITLE
Formatear citaCarga para Google Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Aplicación PWA para seguimiento de cargas en tiempo real, conectada a Google Sh
 - Nombre de la hoja: `Tabla_1`
 - Columnas esperadas:
   - Trip, Caja, Referencia, Cliente, Destino, Estatus, Segmento, TR-MX, TR-USA, Cita carga, Llegada carga, Cita entrega, Llegada entrega, Comentarios, Docs, Tracking
+- Las fechas deben enviarse en formato `DD/MM/YYYY HH:mm:ss` (ejemplo: `26/08/2025 22:00:00`).
 
 ## Ejemplo de JSON de muestra
 ```json

--- a/app.js
+++ b/app.js
@@ -445,11 +445,17 @@ async function main(){
   $('#addForm').addEventListener('submit', async ev=>{
     ev.preventDefault();
     const form = ev.target;
+    const toGASDate = v => {
+      if(!v) return '';
+      const d = new Date(v);
+      const pad = n => String(n).padStart(2, '0');
+      return `${pad(d.getDate())}/${pad(d.getMonth()+1)}/${d.getFullYear()} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+    };
     const data = {
       trip: form.trip.value.trim(),
       estatus: form.estatus.value.trim(),
       cliente: form.cliente.value.trim(),
-      citaCarga: form.citaCarga.value
+      citaCarga: toGASDate(form.citaCarga.value)
     };
     const ok = await addRecord(data);
     if(ok){


### PR DESCRIPTION
## Summary
- Convertir la fecha de cita de carga al formato `DD/MM/YYYY HH:mm:ss` antes de enviarla al backend.
- Documentar en el README el formato de fecha requerido por el backend.

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28e5aeaf0832b8879e1f5594b53af