### PR TITLE
Show detailed API error messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -197,7 +197,7 @@ async function updateDelivered(trip){
     return true;
   }catch(err){
     console.error('updateDelivered error', err);
-    toast('Error al registrar entrega');
+    toast('Error al registrar entrega: ' + err.message);
     return false;
   }
 }
@@ -227,7 +227,7 @@ async function addRecord(data){
     return true;
   }catch(err){
     console.error('addRecord error', err);
-    toast('Error al agregar');
+    toast('Error al agregar: ' + err.message);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- display server error details in addRecord toast
- mirror detailed error handling for updateDelivered

## Testing
- `npm test` (fails: could not find package.json)
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b28e609840832bbd1429741fc957d0