### PR TITLE
Use explicit sheet ID in Apps Script

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -8,7 +8,7 @@ function doPost(e) {
   try {
     var data = JSON.parse(e.postData.contents);
     if (data.action === 'add') {
-      var sheet = SpreadsheetApp.getActive().getSheetByName('Tabla_1');
+      var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName('Tabla_1');
       if (!sheet) throw new Error('Sheet Tabla_1 not found');
       var row = [
         data.trip || '',
@@ -47,7 +47,7 @@ function doGet(e) {
   output.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
 
   try {
-    var sheet = SpreadsheetApp.getActive().getSheetByName('Tabla_1');
+    var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName('Tabla_1');
     if (!sheet) throw new Error('Sheet Tabla_1 not found');
     var data = sheet.getDataRange().getValues();
     output.setContent(JSON.stringify({ data: data }));


### PR DESCRIPTION
## Summary
- Access sheet by ID in Apps Script `doPost` to avoid relying on the active spreadsheet
- Access sheet by ID in Apps Script `doGet` for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5d91d078c832ba822d5cd86759f0b