### PR TITLE
refactor: centralize sheet name constant

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -1,3 +1,5 @@
+const SHEET_NAME = 'Tabla_1';
+
 function doPost(e) {
   var output = ContentService.createTextOutput();
   output.setMimeType(ContentService.MimeType.JSON);
@@ -8,8 +10,8 @@ function doPost(e) {
   try {
     var data = JSON.parse(e.postData.contents);
     if (data.action === 'add') {
-      var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName('Tabla_1');
-      if (!sheet) throw new Error('Sheet Tabla_1 not found');
+      var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName(SHEET_NAME);
+      if (!sheet) throw new Error('Sheet ' + SHEET_NAME + ' not found');
       var row = [
         data.trip || '',
         '', // Caja
@@ -47,8 +49,8 @@ function doGet(e) {
   output.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
 
   try {
-    var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName('Tabla_1');
-    if (!sheet) throw new Error('Sheet Tabla_1 not found');
+    var sheet = SpreadsheetApp.openById('1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms').getSheetByName(SHEET_NAME);
+    if (!sheet) throw new Error('Sheet ' + SHEET_NAME + ' not found');
     var data = sheet.getDataRange().getValues();
     output.setContent(JSON.stringify({ data: data }));
   } catch (err) {


### PR DESCRIPTION
## Summary
- Use global `SHEET_NAME` constant in Apps Script backend
- Remove redundant local sheet name declaration in `doPost`

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5dbf1e2c0832b9bccbd2b4294abdb