### PR TITLE
Handle empty postData in Apps Script doPost

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -1,6 +1,14 @@
 const SHEET_NAME = 'Tabla_1';
 
 function doPost(e) {
+  if (!e.postData) {
+    return ContentService.createTextOutput('')
+      .setMimeType(ContentService.MimeType.JSON)
+      .setHeader('Access-Control-Allow-Origin', '*')
+      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
+      .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  }
+
   var output = ContentService.createTextOutput();
   output.setMimeType(ContentService.MimeType.JSON);
   output.setHeader('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
## Summary
- Return empty JSON response when Apps Script `doPost` receives no `postData`
- Preserve existing logic for the `add` action

## Testing
- `node fmtDate.test.js`
- `curl -i -X POST https://script.google.com/macros/s/AKfycbzwh8M5J7n0OUVHzROjd7TaDdfb5lMAMwm_3oRhUbIL53JSQZkijcy-6v3yPrTgUNMK/exec -d action=add&trip=1&cliente=Foo&estatus=Bar&citaCarga=01/01/2024` *(fails: HTTP 403 - likely environment restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5ae44a0832b8cb6ad3285022900