### PR TITLE
Corrige desajuste de fechas en la PWA

### DIFF
--- a/fmtDate.test.js
+++ b/fmtDate.test.js
@@ -19,4 +19,16 @@ assert.strictEqual(fmtDate(diffSample, 'en-US'), '08/30/2025 08:00 AM');
 assert.strictEqual(fmtDate(diffSample, 'es-MX'), '30/08/2025 08:00 a.m.');
 assert.strictEqual(fmtDate(diffSample, 'de-DE'), '30.08.2025 08:00');
 
+// ISO string with explicit Z should be treated as local time
+const isoZSample = '2024-06-09T15:30:00Z';
+assert.strictEqual(fmtDate(isoZSample, 'en-US'), '06/09/2024 03:30 PM');
+assert.strictEqual(fmtDate(isoZSample, 'es-MX'), '09/06/2024 03:30 p.m.');
+assert.strictEqual(fmtDate(isoZSample, 'de-DE'), '09.06.2024 15:30');
+
+// Short d/m/yyyy without leading zeros
+const shortSample = '1/9/2025 12:00';
+assert.strictEqual(fmtDate(shortSample, 'en-US'), '09/01/2025 12:00 PM');
+assert.strictEqual(fmtDate(shortSample, 'es-MX'), '01/09/2025 12:00 p.m.');
+assert.strictEqual(fmtDate(shortSample, 'de-DE'), '01.09.2025 12:00');
+
 console.log('All fmtDate tests passed.');


### PR DESCRIPTION
## Resumen
- Manejo de fechas más flexible con soporte para `d/m/yyyy hh:mm` y cadenas ISO sin aplicar desfases de zona horaria.
- Formateo de fechas basado en `parseDate` para evitar corrimientos de 6 horas.
- Pruebas ampliadas para cubrir formatos sin ceros iniciales y cadenas ISO con `Z`.

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62d66ae3c832bbc050ca3c5b06a34