### PR TITLE
Display times in 24-hour format

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,15 +54,21 @@ function parseDate(v){
   }
 
   if(typeof v === 'string'){
-    // Formato "d/m/yyyy hh:mm[:ss]"
-    let m = v.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?$/);
+    // Formato "d/m/yyyy hh:mm[:ss]" con opcional AM/PM
+    let m = v.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\s*(AM|PM))?)?$/i);
     if(m){
-      const [,day,month,year,h='0',min='0',s='0'] = m;
+      const [,day,month,year,h='0',min='0',s='0',ampm] = m;
+      let hour = parseInt(h,10);
+      if(ampm){
+        const isPM = ampm.toUpperCase() === 'PM';
+        if(isPM && hour < 12) hour += 12;
+        if(!isPM && hour === 12) hour = 0;
+      }
       return new Date(
         parseInt(year,10),
         parseInt(month,10)-1,
         parseInt(day,10),
-        parseInt(h,10),
+        hour,
         parseInt(min,10),
         parseInt(s,10)
       );

--- a/fmtDate.test.js
+++ b/fmtDate.test.js
@@ -31,4 +31,10 @@ assert.strictEqual(fmtDate(shortSample, 'en-US'), '09/01/2025 12:00');
 assert.strictEqual(fmtDate(shortSample, 'es-MX'), '01/09/2025 12:00');
 assert.strictEqual(fmtDate(shortSample, 'de-DE'), '01.09.2025 12:00');
 
+// Soportar formato con AM/PM
+const ampmSample = '09/06/2024 03:30 PM';
+assert.strictEqual(fmtDate(ampmSample, 'en-US'), '06/09/2024 15:30');
+assert.strictEqual(fmtDate(ampmSample, 'es-MX'), '09/06/2024 15:30');
+assert.strictEqual(fmtDate(ampmSample, 'de-DE'), '09.06.2024 15:30');
+
 console.log('All fmtDate tests passed.');

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
           <input name="cliente" required />
         </label>
         <label>Cita carga
-          <input type="datetime-local" name="citaCarga" required />
+          <input type="datetime-local" name="citaCarga" required lang="es-MX" />
         </label>
         <div class="modal-actions">
           <button type="button" id="cancelAdd" class="btn-mini">Cancelar</button>


### PR DESCRIPTION
## Summary
- Convert AM/PM formatted dates to 24-hour values during parsing
- Force datetime input to use Spanish locale for 24‑hour picker
- Add tests covering 12-hour strings

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b64735dbd0832b84fce9a8b4594c2a