### PR TITLE
Reduce table body font size to 12px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,7 @@ html,body{
 #loadsTable tbody td{
   padding: 10px; border-bottom:1px solid var(--row-border);
   vertical-align: middle;
+  font-size:12px;
 }
 
 /* No cortar fechas/textos importantes */


### PR DESCRIPTION
## Summary
- Decrease table body cell text size to 12px

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b663efe95c832b96894bbf39f59f00