### PR TITLE
Renombrar tablero y centrar título

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Seguimiento de Cargas PWA
+# Tablero de seguimiento PWA
 
 Aplicación PWA para seguimiento de cargas en tiempo real, conectada a Google Sheets.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Seguimiento de Cargas</title>
+  <title>Tablero de seguimiento</title>
   <link rel="manifest" href="./manifest.json"/>
   <link rel="stylesheet" href="./styles.css"/>
   <meta name="theme-color" content="#0F2C5C"/>
@@ -11,7 +11,7 @@
 <body>
   <header class="app-header">
     <img src="assets/logo.png" alt="TM Transportation" class="app-logo"/>
-    <h1>Seguimiento de Cargas</h1>
+    <h1>Tablero de seguimiento</h1>
   </header>
 
     <!-- Menú lateral -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Seguimiento de Cargas",
-  "short_name": "Cargas",
+  "name": "Tablero de seguimiento",
+  "short_name": "Tablero",
   "start_url": "/seguimiento_cargas_pwa/",
   "scope": "/seguimiento_cargas_pwa/",
   "display": "standalone",

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,14 @@ html,body{
   padding: 14px 20px;
   box-shadow: inset 0 0 1px rgba(255,255,255,.08);
   margin-left:180px;
+  position:relative;
+}
+.app-header h1{
+  position:absolute;
+  left:50%;
+  transform:translateX(-50%);
+  font-size:calc(2rem - 4px);
+  margin:0;
 }
 .app-logo{ height:40px; margin-right:8px; }
 


### PR DESCRIPTION
## Summary
- Cambiar nombre visible de la app a "Tablero de seguimiento"
- Centrar el título principal y reducir su tamaño de fuente
- Actualizar manifest y README con el nuevo nombre

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b668790140832b9237514a4e3400f7