### PR TITLE
Add editable status dropdowns for trips

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
           <input name="trip" required />
         </label>
         <label>Estatus
-          <input name="estatus" required />
+          <select name="estatus" required></select>
         </label>
         <label>Cliente
           <input name="cliente" required />
@@ -113,7 +113,7 @@
           <input name="destino" />
         </label>
         <label>Estatus
-          <input name="estatus" />
+          <select name="estatus"></select>
         </label>
         <label>Segmento
           <input name="segmento" />

--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,11 @@ html,body{
 .link:hover{ text-decoration:underline; }
 .trip-edit{ cursor:pointer; text-decoration:underline; }
 
+.status-select{
+  background:#0b1f3d; border:1px solid #1f3e73; color:var(--text);
+  border-radius:8px; padding:4px;
+}
+
 /* ====== Toast ====== */
 .toast{
   position:fixed; right:16px; bottom:16px; background:#111827;
@@ -153,7 +158,7 @@ html,body{
 }
 .modal-content h2{ margin-top:0; }
 .modal-content label{ display:flex; flex-direction:column; gap:4px; margin-bottom:10px; }
-.modal-content input{ background:#0b1f3d; border:1px solid #1f3e73; color:var(--text); border-radius:10px; padding:8px; }
+.modal-content input, .modal-content select{ background:#0b1f3d; border:1px solid #1f3e73; color:var(--text); border-radius:10px; padding:8px; }
 .modal-actions{ display:flex; justify-content:flex-end; gap:10px; margin-top:12px; }
 
 /* ====== Menú lateral ====== */


### PR DESCRIPTION
## Summary
- Replace status inputs with dropdowns listing all possible statuses
- Allow updating trip status directly from the table and via modals
- Style new selects to match existing UI

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b66c87ea40832b9a4006061e00e668