### PR TITLE
Show status text with arrow-only select

### DIFF
--- a/app.js
+++ b/app.js
@@ -430,6 +430,14 @@ function renderRows(rows, hiddenCols=[]){
     addTextCell(tr, r[COL.destino]);
 
     const statusTd = document.createElement('td');
+    const wrapper = document.createElement('div');
+    wrapper.className = 'status-wrapper';
+
+    const statusText = document.createElement('span');
+    statusText.className = 'status-text';
+    statusText.textContent = r[COL.estatus] || '';
+    wrapper.appendChild(statusText);
+
     const sel = document.createElement('select');
     sel.className = 'status-select';
     fillStatusSelect(sel, r[COL.estatus]);
@@ -463,7 +471,8 @@ function renderRows(rows, hiddenCols=[]){
         ev.target.value = r[COL.estatus] || '';
       }
     });
-    statusTd.appendChild(sel);
+    wrapper.appendChild(sel);
+    statusTd.appendChild(wrapper);
     tr.appendChild(statusTd);
 
     addTextCell(tr, r[COL.segmento]);

--- a/styles.css
+++ b/styles.css
@@ -134,9 +134,29 @@ html,body{
 .link:hover{ text-decoration:underline; }
 .trip-edit{ cursor:pointer; text-decoration:underline; }
 
+.status-wrapper{
+  position:relative;
+  display:inline-block;
+}
+
+.status-text{
+  padding-right:16px;
+}
+
 .status-select{
-  background:#0b1f3d; border:1px solid #1f3e73; color:var(--text);
-  border-radius:8px; padding:4px;
+  position:absolute;
+  top:0;
+  right:0;
+  bottom:0;
+  width:20px;
+  background:transparent;
+  border:none;
+  text-indent:-9999px;
+  cursor:pointer;
+}
+
+.status-select option{
+  text-indent:0;
 }
 
 /* ====== Toast ====== */


### PR DESCRIPTION
## Summary
- Display status text with a separate arrow-only select in the table
- Style status cell to hide select text while keeping dropdown arrow visible

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67143e6c0832b887cfb5732f81617