### PR TITLE
fix: daily menu only shows today's appointments

### DIFF
--- a/app.js
+++ b/app.js
@@ -542,9 +542,9 @@ function renderGeneral(rows){
 
 function renderDaily(rows){
   const today = new Date();
-  today.setUTCHours(0,0,0,0);
+  today.setHours(0,0,0,0);
   const tomorrow = new Date(today);
-  tomorrow.setUTCDate(today.getUTCDate() + 1);
+  tomorrow.setDate(today.getDate() + 1);
   const allowed = ['in transit mx','live','drop','loading','mty yard','qro yard'];
   const filtered = rows.filter(r=>{
     const status = String(r[COL.estatus]||'').trim().toLowerCase();


### PR DESCRIPTION
## Summary
- ensure daily loads filter uses local date boundaries

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b673c6ec08832bb65929859c9712b3