### PR TITLE
style: adjust status select arrow and colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@ html,body{
 .status-select{
   position:absolute;
   top:0;
-  right:-4px;
+  right:-16px;
   bottom:0;
   width:24px;
   -webkit-appearance:none;
@@ -156,9 +156,12 @@ html,body{
   border:none;
   text-indent:-9999px;
   cursor:pointer;
+  color:var(--text);
 }
 
 .status-select option{
+  background:var(--card);
+  color:var(--text);
   text-indent:0;
 }
 


### PR DESCRIPTION
## Summary
- Shift status column dropdown arrow further right for better spacing
- Style status dropdown menu to use app color palette

## Testing
- `node fmtDate.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b67a89d3b8832b8bfe4b7b394d9a6a