### PR TITLE
fix: ensure modal overlays table headers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -177,6 +177,7 @@ html,body{
 .modal{
   position:fixed; inset:0; display:flex; align-items:center; justify-content:center;
   background:rgba(0,0,0,.5); visibility:hidden; opacity:0; transition:.25s;
+  z-index:1000;
 }
 .modal.show{ visibility:visible; opacity:1; }
 .modal-content{


### PR DESCRIPTION
## Summary
- ensure modal overlay appears above sticky table headers

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67e8b78cc832ba02b0e9775c4b4b2