### PR TITLE
Add CI check for locale formatting

### DIFF
--- a/.github/workflows/locale-check.yml
+++ b/.github/workflows/locale-check.yml
@@ -1,0 +1,16 @@
+name: locale-check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: node fmtDate.test.js
+      - run: node scripts/check-locale.js

--- a/scripts/check-locale.js
+++ b/scripts/check-locale.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Fails if any JS file uses toLocaleDateString/toLocaleTimeString directly.
+ * The fmtDate helper in app.js is whitelisted.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const FORBIDDEN = ['toLocaleDateString', 'toLocaleTimeString'];
+
+function walk(dir, acc = []) {
+  for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (dirent.name === 'node_modules' || dirent.name === '.git') continue;
+    const res = path.join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      walk(res, acc);
+    } else if (dirent.isFile() && res.endsWith('.js') && res !== path.join(__dirname, 'check-locale.js')) {
+      acc.push(res);
+    }
+  }
+  return acc;
+}
+
+function findFmtDateRanges(content) {
+  const lines = content.split(/\r?\n/);
+  const ranges = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/function\s+fmtDate\s*\(/.test(lines[i])) {
+      let depth = 0;
+      for (let j = i; j < lines.length; j++) {
+        const line = lines[j];
+        depth += (line.match(/{/g) || []).length;
+        depth -= (line.match(/}/g) || []).length;
+        if (j > i && depth === 0) {
+          ranges.push([i, j]);
+          break;
+        }
+      }
+    }
+  }
+  return ranges;
+}
+
+function lineInRanges(line, ranges) {
+  return ranges.some(([start, end]) => line >= start && line <= end);
+}
+
+let violations = [];
+
+for (const file of walk(path.resolve(__dirname, '..'))) {
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const ranges = file.endsWith('app.js') ? findFmtDateRanges(content) : [];
+
+  lines.forEach((line, idx) => {
+    for (const m of FORBIDDEN) {
+      if (line.includes(m) && !lineInRanges(idx, ranges)) {
+        violations.push(`${path.relative(process.cwd(), file)}:${idx + 1} -> ${m}`);
+      }
+    }
+  });
+}
+
+if (violations.length) {
+  console.error('Direct use of locale formatting methods detected:');
+  violations.forEach(v => console.error('  ' + v));
+  process.exit(1);
+} else {
+  console.log('No forbidden locale formatting methods found.');
+}


### PR DESCRIPTION
## Summary
- add script to detect direct toLocaleDateString/toLocaleTimeString calls
- run locale check and existing fmtDate tests in CI

## Testing
- `node scripts/check-locale.js`
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b725a5561c832b8c8eedfe8cb196bd