### PR TITLE
Handle timezone offsets in ISO date parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,11 +83,17 @@ function parseDate(v){
     }
 
     // Formato ISO con o sin zona horaria
-    m = v.match(/^(\d{4}-\d{2}-\d{2})[T\s](\d{2}:\d{2}(?::\d{2})?)(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/);
+    m = v.match(/^(\d{4}-\d{2}-\d{2})[T\s](\d{2}:\d{2}(?::\d{2})?)(?:\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/);
     if(m){
-      // eliminar zona horaria para tratarlo como hora local
-      const cleaned = v.replace(/(?:Z|[+-]\d{2}:?\d{2})$/,'');
-      return new Date(cleaned);
+      const tz = m[3];
+      if(tz){
+        // Si trae información de zona horaria, dejamos que Date la interprete
+        return new Date(v);
+      }
+      // Sin zona horaria explícita -> interpretar como hora local
+      const [year,month,day] = m[1].split('-').map(Number);
+      const [hour,minute,second='0'] = m[2].split(':');
+      return new Date(year, month-1, Number(day), Number(hour), Number(minute), Number(second));
     }
   }
 

--- a/fmtDate.test.js
+++ b/fmtDate.test.js
@@ -20,11 +20,11 @@ assert.strictEqual(fmtDate(diffSample, 'en-US'), '08/30/2025 08:00');
 assert.strictEqual(fmtDate(diffSample, DEFAULT_LOCALE), '30/08/2025 08:00');
 assert.strictEqual(fmtDate(diffSample, 'de-DE'), '30.08.2025 08:00');
 
-// ISO string with explicit Z should be treated as local time
-const isoZSample = '2024-06-09T15:30:00Z';
-assert.strictEqual(fmtDate(isoZSample, 'en-US'), '06/09/2024 15:30');
-assert.strictEqual(fmtDate(isoZSample, DEFAULT_LOCALE), '09/06/2024 15:30');
-assert.strictEqual(fmtDate(isoZSample, 'de-DE'), '09.06.2024 15:30');
+// ISO string with explicit Z should keep the correct time
+const isoZSample = '2024-06-09T09:00:00Z';
+assert.strictEqual(fmtDate(isoZSample, 'en-US'), '06/09/2024 09:00');
+assert.strictEqual(fmtDate(isoZSample, DEFAULT_LOCALE), '09/06/2024 09:00');
+assert.strictEqual(fmtDate(isoZSample, 'de-DE'), '09.06.2024 09:00');
 
 // Short d/m/yyyy without leading zeros
 const shortSample = '1/9/2025 12:00';


### PR DESCRIPTION
## Summary
- Handle timezone info in `parseDate` instead of stripping it
- Ensure `fmtDate` formats ISO strings with timezone correctly (keeps 09:00)

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b766c8e750832b959045f7039c8551