### PR TITLE
Aumenta tamaño del modal de edición y fija botones al fondo

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,11 +142,11 @@
         <label>Tracking
           <input name="tracking" />
         </label>
-        <div class="modal-actions">
-          <button type="button" id="cancelEdit" class="btn-mini">Cancelar</button>
-          <button type="submit" class="btn">Guardar</button>
-        </div>
       </form>
+      <div class="modal-actions">
+        <button type="button" id="cancelEdit" class="btn-mini">Cancelar</button>
+        <button type="submit" form="editForm" class="btn">Guardar</button>
+      </div>
     </div>
   </div>
 

--- a/styles.css
+++ b/styles.css
@@ -213,7 +213,7 @@ html,body{
 #editModal .modal-content{
   width:50vw;
   max-width:300px;
-  height:65vh;
+  height:70vh;
   display:flex;
   flex-direction:column;
 }


### PR DESCRIPTION
## Summary
- amplía el alto del modal de edición para mostrar más campos sin hacer scroll
- mueve los botones Cancelar y Guardar fuera del área desplazable y los deja fijos al fondo

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7c1ca0a04832b8946a4d290595782