### PR TITLE
Fix sticky table header spacing to prevent row overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ body{
   overflow:auto;
   margin-top:14px;
   background: var(--panel-2);
-  padding: 12px 0;
+  padding: 0 0 12px;
   border-radius: 14px;
   box-shadow: 0 8px 26px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.05);
   width: 100%;


### PR DESCRIPTION
## Summary
- remove top padding from `.table-wrap` so sticky table headers cover scrolling rows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7c604bde8832bbb2d887257f19b42