### PR TITLE
Style Delivered status as green badge

### DIFF
--- a/app.js
+++ b/app.js
@@ -422,6 +422,10 @@ function renderRows(rows, hiddenCols=[]){
     const statusText = document.createElement('span');
     statusText.className = 'status-text';
     statusText.textContent = r[COL.estatus] || '';
+    const statusVal = (r[COL.estatus] || '').trim().toLowerCase();
+    if(statusVal === 'delivered'){
+      statusText.classList.add('badge','green');
+    }
     wrapper.appendChild(statusText);
 
     const sel = document.createElement('select');


### PR DESCRIPTION
## Summary
- Show 'Delivered' status in table as green badge without checkmark

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7c955714c832ba60907a194238a02