### PR TITLE
Fix status badge padding for status dropdown

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -182,13 +182,13 @@ body{
 }
 
 .status-text{
-  padding-right:16px;
+  padding-right:24px;
 }
 
 .status-select{
   position:absolute;
   top:0;
-  right:-16px;
+  right:0;
   bottom:0;
   width:24px;
   -webkit-appearance:none;


### PR DESCRIPTION
## Summary
- Ensure status badge width matches text by adjusting padding
- Align dropdown arrow inside badge

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7ce1a3ec8832ba260cdbdb9d01b01