### PR TITLE
Highlight overdue cita carga rows

### DIFF
--- a/app.js
+++ b/app.js
@@ -403,6 +403,13 @@ function renderRows(rows, hiddenCols=[]){
     const tr = document.createElement('tr');
     tr.dataset.trip = r[COL.trip];
 
+    const statusVal = (r[COL.estatus] || '').trim().toLowerCase();
+    const citaDate = parseDate(r[COL.citaCarga]);
+    const now = new Date();
+    if(citaDate && citaDate < now && (currentView === 'daily' || statusVal === 'live' || statusVal === 'drop')){
+      tr.classList.add('expired');
+    }
+
     const tripTd = document.createElement('td');
     const tripSpan = document.createElement('span');
     tripSpan.className = 'trip-edit';
@@ -422,7 +429,6 @@ function renderRows(rows, hiddenCols=[]){
     const statusText = document.createElement('span');
     statusText.className = 'status-text';
     statusText.textContent = r[COL.estatus] || '';
-    const statusVal = (r[COL.estatus] || '').trim().toLowerCase();
     if(statusVal === 'delivered'){
       statusText.classList.add('badge','green');
     }

--- a/styles.css
+++ b/styles.css
@@ -29,6 +29,7 @@ body{
   --badge-yellow:#f59e0b;
   --row:#142f54;
   --row-alt:#11284a;
+  --row-overdue:rgba(239,68,68,0.15);
   --row-border:#274770;
   --scroll-track:#4b5563;    /* gris pista */
   --scroll-thumb:#f3f4f6;    /* blanco pulgar */
@@ -138,6 +139,7 @@ body{
 }
 #loadsTable tbody tr{ background: var(--row); }
 #loadsTable tbody tr:nth-child(even){ background: var(--row-alt); }
+#loadsTable tbody tr.expired{ background: var(--row-overdue) !important; }
 #loadsTable tbody td{
   padding: 4px 10px; border-bottom:1px solid var(--row-border);
   vertical-align: middle;


### PR DESCRIPTION
## Summary
- Add light-red row style for loads with past **cita carga**
- Apply overdue highlighting in `renderRows` for daily view or Live/Drop statuses

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7d23a0c60832ba810d140540c6da3