### PR TITLE
Adjust overdue highlighting

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,7 +412,7 @@ function renderRows(rows, hiddenCols=[]){
     const statusVal = (r[COL.estatus] || '').trim().toLowerCase();
     const citaDate = parseDate(r[COL.citaCarga]);
     const now = new Date();
-    if(citaDate && citaDate < now && (currentView === 'daily' || statusVal === 'live' || statusVal === 'drop')){
+    if(citaDate && citaDate < now && (statusVal === 'live' || statusVal === 'drop')){
       tr.classList.add('expired');
     }
 

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,7 @@ body{
   --badge-yellow:#f59e0b;
   --row:#142f54;
   --row-alt:#11284a;
-  --row-overdue:rgba(239,68,68,0.15);
+  --row-overdue:rgba(239,68,68,0.3);
   --row-border:#274770;
   --scroll-track:#4b5563;    /* gris pista */
   --scroll-thumb:#f3f4f6;    /* blanco pulgar */


### PR DESCRIPTION
## Summary
- highlight expired loads only when status is live or drop
- make overdue row color more intense

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7d6ac7ccc832b80b32cec0e8d7da6