### PR TITLE
fix: use local timezone for sheet dates

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -1,6 +1,6 @@
 const SHEET_NAME = 'Tabla_1';
 const AUTH_TOKEN = 'demo-token';
-const SHEET_TIMEZONE = 'UTC'; // keep times without local offsets
+const SHEET_TIMEZONE = 'America/Mexico_City'; // interpret times as local to avoid 6h offset
 
 function isAuthorized(e) {
   return e.parameter && e.parameter.token === AUTH_TOKEN;


### PR DESCRIPTION
## Summary
- Interpret Google Sheets timestamps in America/Mexico_City timezone to match app

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b87fe4f114832b842536f687b064ab