### PR TITLE
Load secure config from JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ echo "window.APP_CONFIG = { API_BASE: '${API_BASE}' };" > config.js
 ```
 
 Los valores sensibles (`AUTH_USERS`, `API_TOKEN`) deben servirse desde un
-endpoint protegido (por ejemplo `/secure-config`) o inyectarse mediante
+endpoint protegido o un archivo JSON (por ejemplo `/secure-config.json`) o inyectarse mediante
 variables de entorno en el backend.
 

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ const SECURE_CONFIG = { authUsers: [], apiToken: '' };
 
 async function loadSecureConfig(){
   try{
-    const res = await fetch('./secure-config', { cache:'no-store' });
+    const res = await fetch('./secure-config.json', { cache:'no-store' });
     if(!res.ok) throw new Error(`HTTP ${res.status}`);
     const json = await res.json();
     SECURE_CONFIG.authUsers = json.AUTH_USERS || json.authUsers || [];


### PR DESCRIPTION
## Summary
- Fetch secure configuration from `secure-config.json` to simplify local setup.
- Update documentation to note configuration is served from a JSON file.

## Testing
- `node fmtDate.test.js`
- `python3 -m http.server 8080` then `node - <<'NODE' ... NODE` to verify `SECURE_CONFIG.authUsers` and login credentials.


------
https://chatgpt.com/codex/tasks/task_e_68b92b7c0c60832b8ad9fb03baf3f77a