### PR TITLE
feat: add bulk upload support

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
 
       <button id="refreshBtn" class="btn">Actualizar</button>
       <button id="addBtn" class="btn" type="button">Agregar</button>
+      <input type="file" id="bulkUpload" accept=".xlsx,.csv"/>
+      <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
+      <div id="bulkUploadStatus" class="upload-status"></div>
     </section>
 
     <section class="table-wrap">
@@ -181,6 +184,7 @@
   <div id="toast" class="toast">OK</div>
 
 <script src="./config.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 <script src="./app.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- add file input and mass upload controls
- parse CSV/XLSX files and send rows to backend
- support bulkAdd action in Apps Script backend

## Testing
- `node fmtDate.test.js`
- `node --check app.js`
- ⚠️ `node --check backend/Code.gs` (fails: Unknown file extension)

------
https://chatgpt.com/codex/tasks/task_e_68b9b12d1380832ba7b8e27071a90ee8