### PR TITLE
Avoid unsupported setStatusCode in Apps Script

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -7,13 +7,16 @@ function isAuthorized(e) {
 }
 
 function createJsonOutput(payload, status) {
+  if (typeof status === 'number') {
+    payload = Object(payload);
+    payload.status = status;
+  }
   return ContentService.createTextOutput()
     .setContent(JSON.stringify(payload))
     .setMimeType(ContentService.MimeType.JSON)
     .setHeader('Access-Control-Allow-Origin', '*')
     .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-    .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
-    .setStatusCode(status);
+    .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
 }
 
 function doPost(e) {


### PR DESCRIPTION
## Summary
- remove unsupported `setStatusCode` call and include status codes in JSON payloads

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9d0ad8e18832b843c2c31a3142279