### PR TITLE
Remove bold styling from app title

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,7 @@ body{
   transform:translateX(-50%);
   font-size:calc(2rem - 4px);
   margin:0;
+  font-weight:normal;
 }
 .app-logo{ height:40px; margin-right:8px; }
 


### PR DESCRIPTION
## Summary
- set font-weight to normal for app header title

## Testing
- `node fmtDate.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bb0c09cca8832ba996dbd8d63db819