### PR TITLE
Add reference field to new record modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -737,6 +737,7 @@ async function main(){
       trip: form.trip.value.trim(),
       ejecutivo: form.ejecutivo.value.trim(),
       estatus: form.estatus.value.trim(),
+      referencia: form.referencia.value.trim(),
       cliente: form.cliente.value.trim(),
       citaCarga: toGASDate(form.citaCarga.value)
     };
@@ -746,6 +747,7 @@ async function main(){
       row[COL.trip] = data.trip;
       row[COL.ejecutivo] = data.ejecutivo;
       row[COL.estatus] = data.estatus;
+      row[COL.referencia] = data.referencia;
       row[COL.cliente] = data.cliente;
       row[COL.citaCarga] = data.citaCarga;
       cache.push(row);

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -51,7 +51,7 @@ function doPost(e) {
         'Ejecutivo': ejecutivo,
         'Trip': p.trip || '',
         'Caja': '',
-        'Referencia': '',
+        'Referencia': p.referencia || '',
         'Cliente': p.cliente || '',
         'Destino': '',
         'Estatus': p.estatus || '',

--- a/index.html
+++ b/index.html
@@ -109,6 +109,9 @@
         <label>Cliente
           <input name="cliente" required />
         </label>
+        <label>Referencia
+          <input name="referencia" />
+        </label>
         <label>Cita carga
           <input type="datetime-local" name="citaCarga" required lang="es-MX" />
         </label>


### PR DESCRIPTION
## Summary
- ask for reference on new record modal and send to backend
- handle reference when submitting and caching new entries
- persist reference in Apps Script add action

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb71e95c38832bb52b6de1fcd5d756