### PR TITLE
Align login form fields

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -310,10 +310,10 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
 }
 
 #loginForm label{
-  width:100px;
+  flex:0 0 100px;
   font-weight:600;
   color:var(--muted);
-  text-align:right;
+  text-align:left;
 }
 
 #loginForm input{


### PR DESCRIPTION
## Summary
- Align login form labels to the left and keep inputs uniform on the right

## Testing
- `node fmtDate.test.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfc381ee4832b93b37995c3f3cb4b