### PR TITLE
Use Fondo-inicio background on login

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -286,7 +286,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   display:flex;
   align-items:center;
   justify-content:center;
-  background:var(--bg);
+  background:var(--bg) url("./assets/Fondo-inicio.png") center/cover no-repeat;
   z-index:2000;
 }
 


### PR DESCRIPTION
## Summary
- Display Fondo-inicio.png as full-screen background when login is required without affecting the login form

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0580297c832bac5a96ea22969bac