### PR TITLE
Redirect to mobile layout on small screens

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,16 @@
    CONFIG
 ========================= */
 
+// Redirect to mobile version for small screens or mobile devices
+if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+  const isMobileWidth = window.innerWidth < 768;
+  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  const alreadyMobile = window.location.pathname.includes('/mobile');
+  if ((isMobileWidth || isMobileUA) && !alreadyMobile) {
+    window.location.href = '/mobile/index.html';
+  }
+}
+
 // URL base del Web App de Apps Script.
 // Se obtiene de `config.js` para poder configurarse al desplegar.
 const API_BASE = (typeof window !== 'undefined' && window.APP_CONFIG?.API_BASE) || '';


### PR DESCRIPTION
## Summary
- Detect window width or mobile user agent on load and redirect to `/mobile/index.html`
- Skip redirect when already in a `/mobile` route

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a7a9254832baa3eb25c4ab2bd51