### PR TITLE
Add mobile-specific stylesheet for PWA

### DIFF
--- a/mobile/styles.css
+++ b/mobile/styles.css
@@ -1,0 +1,94 @@
+/* ====== Mobile Stylesheet ====== */
+
+/* ====== Palette ====== */
+:root{
+  --bg: #0B2341;           /* fondo general */
+  --card:#0f2c5c;          /* header / barra */
+  --panel:#12335f;         /* contenedores */
+  --panel-2:#102a58;
+  --text:#e7eefc;
+  --muted:#9fb3d9;
+  --accent:#2563eb;        /* azul botón */
+  --accent-2:#1b4fc6;
+  --badge-green:#16a34a;
+  --badge-blue:#2563eb;
+  --badge-red:#ef4444;
+  --badge-purple:#9333ea;
+  --badge-yellow:#f59e0b;
+  --row:#142f54;
+  --row-alt:#11284a;
+  --row-overdue:rgba(239,68,68,0.3);
+  --row-border:#274770;
+}
+
+/* ====== Reset ====== */
+*{ box-sizing:border-box; }
+html,body{
+  margin:0;
+  padding:0;
+  font-family:Roboto,system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+  background:var(--bg);
+  color:var(--text);
+}
+
+/* ====== Mobile Header ====== */
+.m-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  background:var(--card);
+  padding:12px 16px;
+  box-shadow:inset 0 0 1px rgba(255,255,255,.08);
+}
+.m-header__title{
+  font-size:1.25rem;
+  margin:0;
+  font-weight:normal;
+}
+.m-header__logo{ height:32px; }
+
+/* ====== Content ====== */
+.m-container{
+  padding:16px;
+}
+
+/* ====== Bottom Navigation ====== */
+.m-nav{
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  display:flex;
+  justify-content:space-around;
+  background:var(--panel);
+  border-top:1px solid var(--row-border);
+}
+.m-nav__item{
+  flex:1;
+  text-align:center;
+  padding:10px 0;
+  color:var(--text);
+  text-decoration:none;
+  font-weight:600;
+}
+.m-nav__item--active{
+  background:var(--panel-2);
+}
+
+/* ====== Cards ====== */
+.m-card{
+  background:var(--panel);
+  border-radius:12px;
+  padding:16px;
+  margin-bottom:12px;
+  box-shadow:0 4px 10px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
+}
+.m-card__title{
+  margin:0 0 8px;
+  font-size:1rem;
+  font-weight:600;
+}
+.m-card__body{
+  font-size:.875rem;
+  color:var(--muted);
+}


### PR DESCRIPTION
## Summary
- add standalone mobile stylesheet with design rules for mobile-only elements

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a7e3618832b8f423d92b4be4054