### PR TITLE
Add mobile PWA service worker and manifest

### DIFF
--- a/mobile/manifest.json
+++ b/mobile/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tablero de seguimiento",
+  "short_name": "Tablero",
+  "start_url": "/mobile/",
+  "scope": "/mobile/",
+  "display": "standalone",
+  "background_color": "#082341",
+  "theme_color": "#0F2C5C",
+  "icons": [
+    {
+      "src": "/assets/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/mobile/sw.js
+++ b/mobile/sw.js
@@ -1,0 +1,72 @@
+// Service Worker para la PWA móvil con cachés exclusivos
+const CACHE_NAME = 'cargas-pwa-mobile-v1';
+const DYNAMIC_CACHE = 'cargas-pwa-mobile-dynamic-v1';
+const ASSETS = [
+  '/mobile/',
+  '/mobile/index.html',
+  '/styles.css',
+  '/app.js',
+  '/assets/logo.png',
+  '/mobile/manifest.json',
+  '/offline.html',
+];
+
+const ASSET_URLS = ASSETS.map(a => new URL(a, self.location).pathname);
+
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open(CACHE_NAME).then(c => c.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(k => ![CACHE_NAME, DYNAMIC_CACHE].includes(k)).map(k => caches.delete(k))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', e => {
+  const { request } = e;
+
+  if (request.method !== 'GET') {
+    e.respondWith(fetch(request));
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (url.pathname.endsWith('/config.js')) {
+    e.respondWith(fetch(request));
+    return;
+  }
+
+  if (ASSET_URLS.includes(url.pathname)) {
+    e.respondWith((async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(request);
+      const fetchPromise = fetch(request)
+        .then(response => {
+          cache.put(request, response.clone());
+          return response;
+        })
+        .catch(async () => cached || (await caches.match('/offline.html')));
+      return cached || fetchPromise;
+    })());
+    return;
+  }
+
+  e.respondWith((async () => {
+    try {
+      const response = await fetch(request);
+      const cache = await caches.open(DYNAMIC_CACHE);
+      cache.put(request, response.clone());
+      return response;
+    } catch {
+      const cached = await caches.match(request);
+      return cached || (await caches.match('/offline.html'));
+    }
+  })());
+});


### PR DESCRIPTION
## Summary
- add mobile-specific service worker with unique `cargas-pwa-mobile-*` cache names
- provide mobile manifest with `/mobile/` scope and start URL

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a808fbc832b83b3765c293dc63b