### PR TITLE
Fix mobile redirect for subdirectory deployment

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,8 @@ if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
   const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
   const alreadyMobile = window.location.pathname.includes('/mobile');
   if ((isMobileWidth || isMobileUA) && !alreadyMobile) {
-    window.location.href = '/mobile/index.html';
+    // Use a relative path to support deployments under subdirectories
+    window.location.href = 'mobile/index.html';
   }
 }
 

--- a/mobile/manifest.json
+++ b/mobile/manifest.json
@@ -1,19 +1,19 @@
 {
   "name": "Tablero de seguimiento",
   "short_name": "Tablero",
-  "start_url": "/mobile/",
-  "scope": "/mobile/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#082341",
   "theme_color": "#0F2C5C",
   "icons": [
     {
-      "src": "/assets/icon-192.png",
+      "src": "../assets/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/assets/icon-512.png",
+      "src": "../assets/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/mobile/sw.js
+++ b/mobile/sw.js
@@ -2,13 +2,13 @@
 const CACHE_NAME = 'cargas-pwa-mobile-v1';
 const DYNAMIC_CACHE = 'cargas-pwa-mobile-dynamic-v1';
 const ASSETS = [
-  '/mobile/',
-  '/mobile/index.html',
-  '/mobile/styles.css',
-  '/mobile/app.js',
-  '/assets/logo.png',
-  '/mobile/manifest.json',
-  '/offline.html',
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  '../assets/logo.png',
+  './manifest.json',
+  '../offline.html',
 ];
 
 const ASSET_URLS = ASSETS.map(a => new URL(a, self.location).pathname);
@@ -52,7 +52,7 @@ self.addEventListener('fetch', e => {
           cache.put(request, response.clone());
           return response;
         })
-        .catch(async () => cached || (await caches.match('/offline.html')));
+        .catch(async () => cached || (await caches.match('../offline.html')));
       return cached || fetchPromise;
     })());
     return;
@@ -66,7 +66,7 @@ self.addEventListener('fetch', e => {
       return response;
     } catch {
       const cached = await caches.match(request);
-      return cached || (await caches.match('/offline.html'));
+      return cached || (await caches.match('../offline.html'));
     }
   })());
 });


### PR DESCRIPTION
## Summary
- Use relative path when redirecting to the mobile version so the app works when hosted under a subdirectory
- Adjust mobile PWA manifest and service worker to reference assets with relative paths

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd145b5f9c832b8ece9c8d3d48d874