### PR TITLE
Disable mobile redirect to show desktop UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,15 +3,17 @@
 ========================= */
 
 // Redirect to mobile version for small screens or mobile devices
-if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
-  const isMobileWidth = window.innerWidth < 768;
-  const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-  const alreadyMobile = window.location.pathname.includes('/mobile');
-  if ((isMobileWidth || isMobileUA) && !alreadyMobile) {
-    // Use a relative path to support deployments under subdirectories
-    window.location.href = 'mobile/index.html';
-  }
-}
+// NOTE: Mobile view is not yet feature-complete, so the redirect is disabled
+// to allow mobile users to access the full desktop experience.
+// if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+//   const isMobileWidth = window.innerWidth < 768;
+//   const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+//   const alreadyMobile = window.location.pathname.includes('/mobile');
+//   if ((isMobileWidth || isMobileUA) && !alreadyMobile) {
+//     // Use a relative path to support deployments under subdirectories
+//     window.location.href = 'mobile/index.html';
+//   }
+// }
 
 // URL base del Web App de Apps Script.
 // Se obtiene de `config.js` para poder configurarse al desplegar.

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -2,35 +2,13 @@
 <html lang="es">
 <head>
   <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta http-equiv="refresh" content="0; url=../index.html"/>
   <title>Tablero de seguimiento</title>
-  <link rel="manifest" href="./manifest.json"/>
-  <link rel="stylesheet" href="./styles.css"/>
-  <meta name="theme-color" content="#0F2C5C"/>
 </head>
 <body>
-  <header class="m-header">
-    <img src="../assets/logo.png" alt="TM Transportation" class="m-header__logo"/>
-    <h1 class="m-header__title">Tablero</h1>
-    <button id="menuToggle" aria-label="Abrir menú">☰</button>
-  </header>
-
-  <nav class="mobile-menu"></nav>
-
-  <main class="m-container">
-    <p>Bienvenido a la versión móvil.</p>
-  </main>
-
-  <nav class="m-nav">
-    <a href="#" class="m-nav__item m-nav__item--active">Inicio</a>
-  </nav>
-
-  <script src="./config.js"></script>
-  <script src="./app.js"></script>
+  <p>Redireccionando a la versión completa...</p>
   <script>
-    if('serviceWorker' in navigator){
-      navigator.serviceWorker.register('./sw.js').catch(()=>{});
-    }
+    window.location.replace('../index.html');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- disable auto-redirect to unfinished mobile view
- redirect /mobile index to main desktop page

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd21d54810832ba9da4b14299b1df5