### PR TITLE
chore: remove mobile redirect leftovers

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,19 +2,6 @@
    CONFIG
 ========================= */
 
-// Redirect to mobile version for small screens or mobile devices
-// NOTE: Mobile view is not yet feature-complete, so the redirect is disabled
-// to allow mobile users to access the full desktop experience.
-// if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
-//   const isMobileWidth = window.innerWidth < 768;
-//   const isMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-//   const alreadyMobile = window.location.pathname.includes('/mobile');
-//   if ((isMobileWidth || isMobileUA) && !alreadyMobile) {
-//     // Use a relative path to support deployments under subdirectories
-//     window.location.href = 'mobile/index.html';
-//   }
-// }
-
 // URL base del Web App de Apps Script.
 // Se obtiene de `config.js` para poder configurarse al desplegar.
 const API_BASE = (typeof window !== 'undefined' && window.APP_CONFIG?.API_BASE) || '';


### PR DESCRIPTION
## Summary
- remove deprecated mobile redirect logic

## Testing
- `node fmtDate.test.js`
- `node scripts/check-locale.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd25432bf4832b84188ce9d1e583fd