### PR TITLE
chore: improve mobile layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -264,6 +264,11 @@ body{
   position:fixed; top:0; left:0; bottom:0;
   width:160px; background:var(--panel);
   padding-top:20px; display:flex; flex-direction:column;
+  transform: translateX(-100%);
+  transition: transform .3s ease;
+}
+.side-menu.open{
+  transform: translateX(0);
 }
 .side-btn{
   background:transparent; border:0; color:var(--text);
@@ -340,4 +345,16 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   color:#ffb4b4;
   text-align:center;
   margin-top:8px;
+}
+
+@media (max-width: 768px) {
+  .app-header,
+  .container {
+    left: 0;
+    width: 100%;
+  }
+
+  .container {
+    top: 68px;
+  }
 }


### PR DESCRIPTION
## Summary
- hide side menu offscreen and reveal via `.open` class
- adjust header and container positioning on small screens

## Testing
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd27c8d970832bb056728297f414ba