### PR TITLE
Handle missing Trip column

### DIFF
--- a/backend.test.js
+++ b/backend.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+// Load backend script into the current context
+vm.runInThisContext(fs.readFileSync('./backend/Code.gs', 'utf8'));
+
+// Stub Apps Script services
+const sheetData = [['Ejecutivo', 'Cliente']]; // No Trip column
+const sheet = {
+  getDataRange: () => ({
+    getValues: () => sheetData
+  })
+};
+
+global.SpreadsheetApp = {
+  openById: () => ({
+    getSheetByName: () => sheet,
+    getSpreadsheetTimeZone: () => 'UTC'
+  })
+};
+
+global.ContentService = {
+  createTextOutput: () => ({
+    content: '',
+    setContent(c) { this.content = c; return this; },
+    setMimeType() { return this; },
+    setHeader() { return this; }
+  }),
+  MimeType: { JSON: 'application/json', TEXT: 'text/plain' }
+};
+
+// Execute doPost with missing Trip column
+const e = {
+  postData: {},
+  parameter: {
+    token: 'demo-token',
+    action: 'update',
+    originalTrip: '123'
+  }
+};
+
+const result = doPost(e);
+const payload = JSON.parse(result.content);
+assert.strictEqual(payload.error, 'Trip column not found');
+console.log('Trip column missing test passed.');

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -115,7 +115,7 @@ function doPost(e) {
         headerMap[String(headers[i]).trim().toLowerCase()] = i;
       }
       var tripIdx = headerMap['trip'];
-      if (tripIdx === -1) throw new Error('Trip column not found');
+      if (tripIdx == null) throw new Error('Trip column not found');
       var rowIndex = -1;
       for (var i = 1; i < data.length; i++) {
         if (String(data[i][tripIdx]) === String(p.originalTrip)) {


### PR DESCRIPTION
## Summary
- Ensure update action throws `Trip column not found` when trip header is missing
- Add unit test simulating spreadsheet without Trip column

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bde8e5512c832ba420bb2a03d4f69b