### PR TITLE
Remove redundant ejecutivo mapping and add unit test

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -47,7 +47,6 @@ function doPost(e) {
       if (!ejecutivo) throw new Error('Missing ejecutivo');
       var row = new Array(headers.length).fill('');
       var map = {
-        'ejecutivo': 'Ejecutivo',
         'Ejecutivo': ejecutivo,
         'Trip': p.trip || '',
         'Caja': '',

--- a/backend/Code.test.js
+++ b/backend/Code.test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const headers = ['Ejecutivo', 'Trip', 'Caja', 'Referencia', 'Cliente', 'Destino', 'Estatus', 'Segmento', 'TR-MX', 'TR-USA', 'Cita carga', 'Llegada carga', 'Cita entrega', 'Llegada entrega', 'Comentarios', 'Docs', 'Tracking'];
+
+const appendedRows = [];
+
+const sheet = {
+  getDataRange: () => ({ getValues: () => [headers] }),
+  appendRow: (row) => appendedRows.push(row)
+};
+
+const ss = {
+  getSheetByName: () => sheet,
+  getSpreadsheetTimeZone: () => 'UTC'
+};
+
+const sandbox = {
+  SpreadsheetApp: { openById: () => ss },
+  ContentService: {
+    MimeType: { JSON: 'application/json' },
+    createTextOutput: () => ({
+      setContent() { return this; },
+      setMimeType() { return this; },
+      setHeader() { return this; }
+    })
+  },
+  Utilities: { parseDate: (val) => val }
+};
+
+vm.createContext(sandbox);
+vm.runInContext(fs.readFileSync(__dirname + '/Code.gs', 'utf8'), sandbox);
+
+const e = {
+  postData: {},
+  parameter: {
+    token: 'demo-token',
+    action: 'add',
+    ejecutivo: 'Maria',
+    trip: 'T1',
+    referencia: 'R1',
+    cliente: 'C1',
+    estatus: 'E1'
+  }
+};
+
+sandbox.doPost(e);
+
+const row = appendedRows[0];
+assert.strictEqual(row[0], 'Maria');
+console.log('Code.gs tests passed.');


### PR DESCRIPTION
## Summary
- simplify map initialization by removing unused `'ejecutivo'` entry
- add unit test ensuring `'Ejecutivo'` column receives provided value

## Testing
- `node fmtDate.test.js && node backend/Code.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bde8f46254832b9bc43bd3ac5d35c0