### PR TITLE
Use dynamic path for offline fallback in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -52,7 +52,10 @@ self.addEventListener('fetch', e => {
           cache.put(request, response.clone());
           return response;
         })
-        .catch(async () => cached || (await caches.match('/offline.html')));
+        .catch(async () =>
+          cached ||
+          (await caches.match(new URL('./offline.html', self.location).pathname))
+        );
       return cached || fetchPromise;
     })());
     return;
@@ -66,7 +69,10 @@ self.addEventListener('fetch', e => {
       return response;
     } catch {
       const cached = await caches.match(request);
-      return cached || (await caches.match('/offline.html'));
+      return (
+        cached ||
+        (await caches.match(new URL('./offline.html', self.location).pathname))
+      );
     }
   })());
 });


### PR DESCRIPTION
## Summary
- Use `new URL('./offline.html', self.location).pathname` when matching the offline fallback page in the service worker

## Testing
- `node fmtDate.test.js`
- `node scripts/check-locale.js`
- `node /tmp/offline-test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bde8fd6420832bbd3c895b24747424