### PR TITLE
Adjust edit modal width responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -249,7 +249,7 @@ body{
 }
 #editModal .modal-content{
   width:50vw;
-  max-width:300px;
+  min-width:300px;
   height:70vh;
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- ensure edit modal never shrinks below 300px while using half the viewport width

## Testing
- `node fmtDate.test.js`
- `node -e "const widths=[320,500,800,1200]; console.log(widths.map(w=>({w,modal: Math.max(300,0.5*w)})));"`


------
https://chatgpt.com/codex/tasks/task_e_68bde9263084832ba21f1f2ded61a81c