### PR TITLE
Handle dates in bulk upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -332,7 +332,10 @@ async function handleBulkUpload(file){
             workbook = XLSX.read(bytes, { type:'array' });
           }
           const firstSheet = workbook.SheetNames[0];
-          const rows = XLSX.utils.sheet_to_json(workbook.Sheets[firstSheet], { defval:'' });
+          const rows = XLSX.utils.sheet_to_json(
+            workbook.Sheets[firstSheet],
+            { defval:'', raw:false, cellDates:true }
+          );
           resolve(rows);
         }catch(err){ reject(err); }
       };
@@ -364,7 +367,10 @@ async function handleBulkUpload(file){
         ejecutivo: headers.includes('ejecutivo') ? obj[COL.ejecutivo] : '',
         estatus: headers.includes('estatus') ? obj[COL.estatus] : '',
         cliente: headers.includes('cliente') ? obj[COL.cliente] : '',
-        citaCarga: headers.includes('cita carga') ? toGASDate(obj[COL.citaCarga]) : ''
+        citaCarga: headers.includes('cita carga') ? toGASDate(obj[COL.citaCarga]) : '',
+        llegadaCarga: headers.includes('llegada carga') ? toGASDate(obj[COL.llegadaCarga]) : '',
+        citaEntrega: headers.includes('cita entrega') ? toGASDate(obj[COL.citaEntrega]) : '',
+        llegadaEntrega: headers.includes('llegada entrega') ? toGASDate(obj[COL.llegadaEntrega]) : ''
       };
       const ok = await addRecord(payload);
       if(!ok){

--- a/backend.test.js
+++ b/backend.test.js
@@ -2,10 +2,17 @@ const assert = require('assert');
 const fs = require('fs');
 const vm = require('vm');
 
+// Stub services required at load time
+global.PropertiesService = {
+  getScriptProperties: () => ({
+    getProperty: () => 'demo-token'
+  })
+};
+
 // Load backend script into the current context
 vm.runInThisContext(fs.readFileSync('./backend/Code.gs', 'utf8'));
 
-// Stub Apps Script services
+// Stub remaining Apps Script services
 const sheetData = [['Ejecutivo', 'Cliente']]; // No Trip column
 const sheet = {
   getDataRange: () => ({


### PR DESCRIPTION
## Summary
- parse spreadsheet with `raw:false` and `cellDates:true` for reliable date handling
- send all date columns using `toGASDate` during bulk upload
- stub `PropertiesService` in backend tests

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdee7d9a64832ba8bfbaa61ca73456