### PR TITLE
Reduce edit modal size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -248,9 +248,9 @@ body{
   overflow:hidden;
 }
 #editModal .modal-content{
-  width:50vw;
+  width:25vw;
   min-width:300px;
-  height:70vh;
+  height:35vh;
   display:flex;
   flex-direction:column;
 }


### PR DESCRIPTION
## Summary
- Shrink edit modal to 25vw width and 35vh height for a more compact edit form

## Testing
- `node backend.test.js && node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdf57ed0c0832b808aa7d13b931f93