### PR TITLE
Align edit modal fields

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -266,11 +266,15 @@ body{
   display:flex; flex-direction:column; gap:4px; margin-bottom:10px;
 }
 #editModal .modal-content label{
-  flex-direction:row; align-items:center; gap:10px;
+  display:grid;
+  grid-template-columns:120px 1fr;
+  align-items:center;
+  gap:10px;
+  text-align:right;
 }
 #editModal .modal-content label input,
 #editModal .modal-content label select{
-  flex:1;
+  width:100%;
 }
 .modal-content input,
 .modal-content select{


### PR DESCRIPTION
## Summary
- Make edit modal input fields the same width and right-aligned for consistent layout

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdfa2bb8c4832bb23a7d66ad046a2c