### PR TITLE
Align edit modal fields

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -270,7 +270,7 @@ body{
   grid-template-columns:120px 1fr;
   align-items:center;
   gap:10px;
-  text-align:right;
+  text-align:left;
 }
 #editModal .modal-content label input,
 #editModal .modal-content label select{


### PR DESCRIPTION
## Summary
- Align edit modal labels to the left so fields stay on the right for clearer side-by-side editing

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdfbb8f788832baac5a6099d644a32