### PR TITLE
Hide past cancelled loads from Daily view

### DIFF
--- a/app.js
+++ b/app.js
@@ -692,6 +692,8 @@ function renderDaily(rows){
     const status = String(r[COL.estatus]||'').trim().toLowerCase();
     const cita = parseDate(r[COL.citaCarga]);
     if(!cita) return false;
+    // Mostrar cancelados solo si la cita corresponde al día actual
+    if(status === 'cancelled') return cita >= today && cita < tomorrow;
     if(cita >= today && cita < tomorrow) return true;
     if(cita < today && !hideStatuses.includes(status)) return true;
     return false;


### PR DESCRIPTION
## Summary
- Only show `cancelled` loads in Daily view if the appointment date is today.

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be3bfa6414832b954eebc25eecd971