### PR TITLE
Mostrar mensaje de Trip existente en rojo

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,10 +160,9 @@ function fillStatusSelect(sel, current='', allowEmpty=false){
 function toast(msg, type=''){
   const el = $('#toast');
   el.textContent = msg;
-  if(type === 'success'){
-    el.classList.add('success');
-  }else{
-    el.classList.remove('success');
+  el.classList.remove('success','error');
+  if(type){
+    el.classList.add(type);
   }
   el.classList.add('show');
   setTimeout(()=>el.classList.remove('show'),1800);
@@ -180,16 +179,16 @@ function arrayRowToObj(row){
 
 function validateTrip(trip, original=''){
   if(!/^\d+$/.test(trip)){
-    toast('El Trip debe contener solo números');
+    toast('El Trip debe contener solo números','error');
     return false;
   }
   if(Number(trip) < 225000){
-    toast('El Trip debe ser mayor o igual a 225000');
+    toast('El Trip debe ser mayor o igual a 225000','error');
     return false;
   }
   const exists = cache.some(r => String(r[COL.trip]) === trip && String(r[COL.trip]) !== String(original));
   if(exists){
-    toast('El Trip ya existe');
+    toast('El Trip ya existe','error');
     return false;
   }
   return true;
@@ -284,7 +283,7 @@ async function addRecord(data){
       toast('Saved','success');
       return true;
     }
-    toast('Error al agregar: ' + err.message);
+    toast('Error al agregar: ' + err.message,'error');
     return false;
   }
 }
@@ -325,7 +324,7 @@ async function updateRecord(data){
       toast('Saved','success');
       return true;
     }
-    toast('Error al actualizar: ' + err.message);
+    toast('Error al actualizar: ' + err.message,'error');
     return false;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,7 @@ body{
 }
 .toast.show{ opacity:1; transform:translateY(0); }
 .toast.success{ background:#16a34a; color:#fff; }
+.toast.error{ background:#dc2626; color:#fff; }
 
 /* ====== Modal ====== */
 .modal{


### PR DESCRIPTION
## Summary
- Añade un nuevo estilo de toast para errores en rojo
- Muestra en rojo las validaciones de Trip duplicado y otros errores

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be499f7c88832bacc9eae87d9677f9