### PR TITLE
Captura de llegada al seleccionar estatus de entrega

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,21 @@
     </div>
   </div>
 
+  <div id="arrivalModal" class="modal">
+    <div class="modal-content">
+      <h2>Llegada entrega</h2>
+      <form id="arrivalForm">
+        <label>Llegada entrega
+          <input type="datetime-local" name="llegadaEntrega" required lang="es-MX" />
+        </label>
+        <div class="modal-actions">
+          <button type="button" id="cancelArrival" class="btn-mini">Cancelar</button>
+          <button type="submit" class="btn">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <div id="toast" class="toast">OK</div>
 
 <script src="./config.js"></script>


### PR DESCRIPTION
## Summary
- muestra modal para ingresar la llegada de entrega al elegir "At destination" o "Delivered"
- agrega botones Cancelar y Guardar en dicha ventana

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be4dc778e8832b9ac2b072d506a7cf