### PR TITLE
Show arrival modal only when arrival field empty

### DIFF
--- a/app.js
+++ b/app.js
@@ -604,7 +604,9 @@ function renderRows(rows, hiddenCols=[]){
     fillStatusSelect(sel, r[COL.estatus]);
     sel.addEventListener('change', async ev=>{
       const newStatus = ev.target.value;
-      if(['at destination','delivered'].includes(newStatus.trim().toLowerCase())){
+      const statusLower = newStatus.trim().toLowerCase();
+      const llegadaVacia = !String(r[COL.llegadaEntrega] || '').trim();
+      if(['at destination','delivered'].includes(statusLower) && llegadaVacia){
         pendingStatusChange = { row: r, select: ev.target, newStatus };
         $('#arrivalForm input[name="llegadaEntrega"]').value = '';
         $('#arrivalModal').classList.add('show');


### PR DESCRIPTION
## Summary
- Only prompt for arrival time when status becomes At destination or Delivered and arrival is missing

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be5576dc70832b93933db451dbbfb6