### PR TITLE
feat: add date navigation arrows

### DIFF
--- a/app.js
+++ b/app.js
@@ -731,6 +731,23 @@ function renderDaily(rows){
   renderRows(filtered, [9,12,13,15]);
 }
 
+function shiftDateRange(days){
+  const startInput = $('#startDate');
+  const endInput = $('#endDate');
+  const parse = v => {
+    const [y,m,d] = v.split('-').map(Number);
+    return new Date(y, m-1, d);
+  };
+  const format = d => d.toLocaleDateString('en-CA');
+  const start = startInput.value ? parse(startInput.value) : new Date();
+  const end = endInput.value ? parse(endInput.value) : new Date();
+  start.setDate(start.getDate() + days);
+  end.setDate(end.getDate() + days);
+  startInput.value = format(start);
+  endInput.value = format(end);
+  renderRows(cache);
+}
+
 async function main(){
   cache = await fetchData();
   populateStatusFilter(cache);
@@ -750,6 +767,8 @@ async function main(){
   $('#searchBox').addEventListener('input', ()=>renderRows(cache));
   $('#startDate').addEventListener('change', ()=>renderRows(cache));
   $('#endDate').addEventListener('change', ()=>renderRows(cache));
+  $('#prevDay').addEventListener('click', ()=>shiftDateRange(-1));
+  $('#nextDay').addEventListener('click', ()=>shiftDateRange(1));
 
   $('#bulkUploadBtn').addEventListener('click', ()=>{
     const file = $('#bulkUpload').files[0];

--- a/index.html
+++ b/index.html
@@ -52,9 +52,11 @@
 
       <label for="startDate">Cita carga</label>
       <div class="date-range">
+        <button id="prevDay" type="button" class="date-nav-btn">&#x276F;</button>
         <input type="date" id="startDate"/>
         <span class="date-separator">→</span>
         <input type="date" id="endDate"/>
+        <button id="nextDay" type="button" class="date-nav-btn">&#x276E;</button>
       </div>
 
       <button id="refreshBtn" class="btn">Actualizar</button>

--- a/styles.css
+++ b/styles.css
@@ -329,6 +329,14 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   border-radius:0;
 }
 
+.date-range button{
+  background:transparent;
+  border:0;
+  color:var(--text);
+  padding:10px 12px;
+  cursor:pointer;
+}
+
 .date-range .date-separator{
   color:var(--text);
   padding:0 4px;


### PR DESCRIPTION
## Summary
- add arrow buttons alongside Cita carga date inputs to navigate previous/next day
- style navigation buttons and shift date range via JavaScript

## Testing
- `node fmtDate.test.js && node tripValidation.test.js && node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf6fc8af14832b8dc59b8096b847bd