### PR TITLE
Make logo navigate home and clear filters

### DIFF
--- a/app.js
+++ b/app.js
@@ -698,13 +698,17 @@ function renderRows(rows, hiddenCols=[]){
   }
 }
 
-function renderGeneral(rows){
-  currentView = 'general';
+function clearFilters(){
   $('#statusFilter').value = '';
   $('#ejecutivoFilter').value = '';
   $('#searchBox').value = '';
   $('#startDate').value = '';
   $('#endDate').value = '';
+}
+
+function renderGeneral(rows){
+  currentView = 'general';
+  clearFilters();
   renderRows(rows);
 }
 
@@ -750,6 +754,10 @@ async function main(){
   $('#searchBox').addEventListener('input', ()=>renderRows(cache));
   $('#startDate').addEventListener('change', ()=>renderRows(cache));
   $('#endDate').addEventListener('change', ()=>renderRows(cache));
+  $('#homeBtn')?.addEventListener('click', ()=>{
+    clearFilters();
+    renderDaily(cache);
+  });
 
   $('#bulkUploadBtn').addEventListener('click', ()=>{
     const file = $('#bulkUpload').files[0];

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <header class="app-header">
-    <img src="assets/logo.png" alt="TM Transportation" class="app-logo"/>
+    <img src="assets/logo.png" alt="TM Transportation" class="app-logo" id="homeBtn"/>
     <h1>Tablero de seguimiento</h1>
     <button id="logoutBtn" class="btn-mini" style="margin-left:auto;display:none">Cerrar sesión</button>
   </header>

--- a/styles.css
+++ b/styles.css
@@ -79,7 +79,7 @@ body{
   margin:0;
   font-weight:normal;
 }
-.app-logo{ height:40px; margin-right:8px; }
+.app-logo{ height:40px; margin-right:8px; cursor:pointer; }
 
 /* Menu lateral eliminado */
 


### PR DESCRIPTION
## Summary
- Turn the header logo into a home button that returns to *Cargas Diarias* and resets all filters
- Style the logo with a pointer cursor for clickability
- Add helper to clear filters and use it in the new logo handler

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf9554ce78832b9a9258591eb7fc47