### PR TITLE
Clear active filters when opening General view

### DIFF
--- a/app.js
+++ b/app.js
@@ -698,6 +698,11 @@ function renderRows(rows, hiddenCols=[]){
   }
 }
 
+function hasActiveFilters(){
+  return $('#statusFilter').value || $('#ejecutivoFilter').value ||
+         $('#searchBox').value.trim() || $('#startDate').value || $('#endDate').value;
+}
+
 function clearFilters(){
   $('#statusFilter').value = '';
   $('#ejecutivoFilter').value = '';
@@ -708,7 +713,7 @@ function clearFilters(){
 
 function renderGeneral(rows){
   currentView = 'general';
-  clearFilters();
+  if(hasActiveFilters()) clearFilters();
   renderRows(rows);
 }
 


### PR DESCRIPTION
## Summary
- Only clear filters when active before rendering General view
- Add utility to detect active filters

## Testing
- `node fmtDate.test.js`
- `node tripValidation.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf978ca39c832b81e1db77a0fbf411