### PR TITLE
Clear filters when opening daily view

### DIFF
--- a/app.js
+++ b/app.js
@@ -732,6 +732,8 @@ function renderDaily(rows){
   $('#statusFilter').value = '';
   $('#ejecutivoFilter').value = '';
   $('#searchBox').value = '';
+  $('#startDate').value = '';
+  $('#endDate').value = '';
   renderRows(filtered, [9,12,13,15]);
 }
 
@@ -913,7 +915,12 @@ async function main(){
     pendingStatusChange = null;
   });
   $('#generalMenu').addEventListener('click', ()=>renderGeneral(cache));
-  $('#dailyMenu').addEventListener('click', ()=>renderDaily(cache));
+  $('#dailyMenu').addEventListener('click', () => {
+    const hasFilters = $('#statusFilter').value || $('#ejecutivoFilter').value ||
+      $('#searchBox').value || $('#startDate').value || $('#endDate').value;
+    if (hasFilters) clearFilters();
+    renderDaily(cache);
+  });
 
   $('#loadsTable').addEventListener('click', async ev=>{
     const btn = ev.target.closest('button[data-act]');


### PR DESCRIPTION
## Summary
- Reset all filter fields, including date range, when rendering the daily view
- Clear active filters when clicking the "Cargas Diarias" menu option

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf97d2595c832bad78cec0b39459b6