### PR TITLE
Preserve filters after updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -734,11 +734,6 @@ function renderDaily(rows){
     if(cita < today && !hideStatuses.includes(status)) return true;
     return false;
   });
-  $('#statusFilter').value = '';
-  $('#ejecutivoFilter').value = '';
-  $('#searchBox').value = '';
-  $('#startDate').value = '';
-  $('#endDate').value = '';
   renderRows(filtered, [9,12,13,15]);
 }
 


### PR DESCRIPTION
## Summary
- Keep user-selected filters intact when re-rendering the daily view after edits or status changes

## Testing
- `node fmtDate.test.js`
- `node tripValidation.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf9f490224832bad85eb777b7ec91d