### PR TITLE
Fix daily filter default date to use local timezone

### DIFF
--- a/app.js
+++ b/app.js
@@ -712,9 +712,12 @@ function clearFilters(){
 }
 
 function setDefaultDate(){
-  const today = new Date().toISOString().split('T')[0];
-  $('#startDate').value = today;
-  $('#endDate').value = today;
+  const now = new Date();
+  const localDate = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+    .toISOString()
+    .split('T')[0];
+  $('#startDate').value = localDate;
+  $('#endDate').value = localDate;
 }
 
 function renderGeneral(rows){


### PR DESCRIPTION
## Summary
- adjust `setDefaultDate` to compute today's date in the user's local timezone, ensuring the daily filter defaults to the correct day

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfa2078eec832baafe3a9e35d43774