### PR TITLE
Show calendar icons in add and edit forms

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -320,6 +320,26 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator{
   display:none;
 }
 
+#addModal input[type="date"],
+#addModal input[type="time"],
+#addModal input[type="datetime-local"],
+#editModal input[type="date"],
+#editModal input[type="time"],
+#editModal input[type="datetime-local"]{
+  -webkit-appearance:auto;
+  -moz-appearance:auto;
+  appearance:auto;
+}
+
+#addModal input[type="date"]::-webkit-calendar-picker-indicator,
+#addModal input[type="time"]::-webkit-calendar-picker-indicator,
+#addModal input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+#editModal input[type="date"]::-webkit-calendar-picker-indicator,
+#editModal input[type="time"]::-webkit-calendar-picker-indicator,
+#editModal input[type="datetime-local"]::-webkit-calendar-picker-indicator{
+  display:initial;
+}
+
 /* Date range input */
 .date-range{
   display:inline-flex;


### PR DESCRIPTION
## Summary
- Restore calendar icons for date and time inputs in Nuevo registro and Editar registro modals

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfa52be8e0832b8713d31637ea3b36