### PR TITLE
Iconos de calendario blancos en modales de registro

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -329,6 +329,7 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator{
   -webkit-appearance:auto;
   -moz-appearance:auto;
   appearance:auto;
+  color-scheme:dark;
 }
 
 #addModal input[type="date"]::-webkit-calendar-picker-indicator,


### PR DESCRIPTION
## Resumen
- Ajusta los campos de fecha y hora en los modales de alta y edición para mostrar los íconos de calendario en color blanco.

## Pruebas
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfa998d01c832b85bdec1f5a7607f4