### PR TITLE
Add clear button to search filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -707,6 +707,7 @@ function clearFilters(){
   $('#statusFilter').value = '';
   $('#ejecutivoFilter').value = '';
   $('#searchBox').value = '';
+  $('#clearSearch').style.display = 'none';
   $('#startDate').value = '';
   $('#endDate').value = '';
 }
@@ -762,7 +763,17 @@ async function main(){
   });
   $('#statusFilter').addEventListener('change', ()=>renderRows(cache));
   $('#ejecutivoFilter').addEventListener('change', ()=>renderRows(cache));
-  $('#searchBox').addEventListener('input', ()=>renderRows(cache));
+  const searchBox = $('#searchBox');
+  const clearSearch = $('#clearSearch');
+  searchBox.addEventListener('input', () => {
+    clearSearch.style.display = searchBox.value ? 'block' : 'none';
+    renderRows(cache);
+  });
+  clearSearch.addEventListener('click', () => {
+    searchBox.value = '';
+    clearSearch.style.display = 'none';
+    renderRows(cache);
+  });
   $('#startDate').addEventListener('change', ()=>renderRows(cache));
   $('#endDate').addEventListener('change', ()=>renderRows(cache));
   ['#startDate','#endDate'].forEach(sel=>{

--- a/index.html
+++ b/index.html
@@ -48,7 +48,10 @@
       </select>
 
       <label for="searchBox">Buscar:</label>
-      <input id="searchBox" type="text" placeholder="Trip, Caja, Cliente, Destino"/>
+      <div class="search-wrapper">
+        <input id="searchBox" type="text" placeholder="Trip, Caja, Cliente, Destino"/>
+        <button id="clearSearch" type="button" class="clear-search" aria-label="Limpiar búsqueda">×</button>
+      </div>
 
       <label for="startDate">Cita carga</label>
       <div class="date-range">

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,15 @@ body{
 #bulkUpload{
   width:140px;
 }
+
+.search-wrapper{ position:relative; }
+.search-wrapper input{ padding-right:28px; }
+.clear-search{
+  position:absolute;
+  right:8px; top:50%; transform:translateY(-50%);
+  background:none; border:0; color:#fff; cursor:pointer;
+  font-size:16px; line-height:1; display:none;
+}
 .btn{
   background:var(--accent); color:#fff; border:0; border-radius:12px;
   padding:10px 14px; cursor:pointer; font-weight:600;


### PR DESCRIPTION
## Summary
- Add white “×” button to search input to clear active filter
- Style search input wrapper and clear button
- Toggle clear button visibility and implement clearing logic

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfabc26b1c832ba14d4395093186e7