### PR TITLE
Hide cancelled deliveries in Entregas hoy view

### DIFF
--- a/app.js
+++ b/app.js
@@ -755,7 +755,7 @@ function renderEntregasHoy(rows){
   tomorrow.setDate(today.getDate() + 1);
   const filtered = rows.filter(r=>{
     const status = String(r[COL.estatus]||'').trim().toLowerCase();
-    if(status === 'delivered') return false;
+    if(status === 'delivered' || status === 'cancelled') return false;
     const cita = parseDate(r[COL.citaEntrega]);
     if(!cita) return false;
     if(cita >= today && cita < tomorrow) return true;


### PR DESCRIPTION
## Summary
- hide cancelled deliveries from "Entregas hoy" view

## Testing
- `node backend.test.js && node fmtDate.test.js && node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad7e66e8832b82d4892b291195cb