### PR TITLE
Enable calendar icon in arrival modal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -334,7 +334,10 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator{
 #addModal input[type="datetime-local"],
 #editModal input[type="date"],
 #editModal input[type="time"],
-#editModal input[type="datetime-local"]{
+#editModal input[type="datetime-local"],
+#arrivalModal input[type="date"],
+#arrivalModal input[type="time"],
+#arrivalModal input[type="datetime-local"]{
   -webkit-appearance:auto;
   -moz-appearance:auto;
   appearance:auto;
@@ -346,7 +349,10 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator{
 #addModal input[type="datetime-local"]::-webkit-calendar-picker-indicator,
 #editModal input[type="date"]::-webkit-calendar-picker-indicator,
 #editModal input[type="time"]::-webkit-calendar-picker-indicator,
-#editModal input[type="datetime-local"]::-webkit-calendar-picker-indicator{
+#editModal input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+#arrivalModal input[type="date"]::-webkit-calendar-picker-indicator,
+#arrivalModal input[type="time"]::-webkit-calendar-picker-indicator,
+#arrivalModal input[type="datetime-local"]::-webkit-calendar-picker-indicator{
   display:initial;
 }
 


### PR DESCRIPTION
## Summary
- show date/time picker icon in Arrival Modal inputs

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1afae0ee8832bb74e7cbb69683c71