### PR TITLE
fix: add dark background to logo in light theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,11 @@ body{
   font-weight:normal;
 }
 .app-logo{ height:40px; margin-right:8px; cursor:pointer; }
+.theme-light .app-logo{
+  background:#0F2C5C;
+  border-radius:4px;
+  padding:2px;
+}
 
 /* Menu lateral eliminado */
 
@@ -466,6 +471,11 @@ input[type="datetime-local"]::-webkit-calendar-picker-indicator{
   display:block;
   margin:0 auto 10px;
   max-width:150px;
+}
+.theme-light #loginForm .login-logo{
+  background:#0F2C5C;
+  border-radius:4px;
+  padding:4px;
 }
 
 #loginError{


### PR DESCRIPTION
## Summary
- Ensure logos remain visible in light theme by adding dark background color

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4b3b89c08832b985d8292be607421