### PR TITLE
style: unify dark filter styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,10 +137,18 @@ body{
   padding: 14px; border-radius: 14px;
   box-shadow: 0 8px 26px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
 }
-.controls label{ font-weight:600; color:var(--muted); }
-.controls input, .controls select{
-  background:var(--input-bg); border:1px solid var(--input-border);
-  color:var(--text); border-radius:10px; padding:10px 12px;
+.controls label{
+  font-weight:600;
+  color:#fff;
+}
+.controls input,
+.controls select{
+  background:var(--input-bg);
+  background-color:var(--input-bg);
+  border:1px solid var(--input-border);
+  color:var(--text);
+  border-radius:10px;
+  padding:10px 12px;
   outline:none;
 }
 


### PR DESCRIPTION
## Summary
- Set filter labels white in dark mode
- Align filter input backgrounds with search box

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4ba03cb38832bb8444844ece57813