### PR TITLE
feat: add switch-style theme toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1054,10 +1054,12 @@ if (typeof document !== 'undefined') {
 
     if(typeof localStorage !== 'undefined' && localStorage.getItem('theme') === 'light'){
       document.body.classList.add('theme-light');
+      if(themeToggle) themeToggle.checked = true;
     }
 
-    themeToggle?.addEventListener('click', () => {
-      const isLight = document.body.classList.toggle('theme-light');
+    themeToggle?.addEventListener('change', (e) => {
+      const isLight = e.target.checked;
+      document.body.classList.toggle('theme-light', isLight);
       if(typeof localStorage !== 'undefined'){
         if(isLight) localStorage.setItem('theme','light');
         else localStorage.removeItem('theme');

--- a/index.html
+++ b/index.html
@@ -12,7 +12,13 @@
   <header class="app-header">
     <img src="assets/logo.png" alt="TM Transportation" class="app-logo" id="homeBtn"/>
     <h1>Tablero de seguimiento</h1>
-    <button id="themeToggle" class="btn-mini" style="margin-left:auto">Tema</button>
+    <div class="theme-switch">
+      <span>Tema</span>
+      <label>
+        <input type="checkbox" id="themeToggle" />
+        <span class="slider"></span>
+      </label>
+    </div>
     <button id="logoutBtn" class="btn-mini" style="display:none">Cerrar sesión</button>
   </header>
 

--- a/styles.css
+++ b/styles.css
@@ -270,6 +270,51 @@ body{
   transition:background-color .2s ease;
 }
 .btn-mini:hover{ background:#eef2ff; }
+
+/* ====== Theme Switch ====== */
+.theme-switch{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  margin-left:auto;
+}
+.theme-switch label{
+  position:relative;
+  display:inline-block;
+  width:40px;
+  height:20px;
+}
+.theme-switch input{
+  opacity:0;
+  width:0;
+  height:0;
+}
+.theme-switch .slider{
+  position:absolute;
+  cursor:pointer;
+  top:0; left:0; right:0; bottom:0;
+  background:var(--muted);
+  border-radius:20px;
+  transition:.4s;
+}
+.theme-switch .slider:before{
+  position:absolute;
+  content:""; 
+  height:16px;
+  width:16px;
+  left:2px;
+  bottom:2px;
+  background:#fff;
+  border-radius:50%;
+  transition:.4s;
+}
+.theme-switch input:checked + .slider{
+  background:var(--accent);
+}
+.theme-switch input:checked + .slider:before{
+  transform:translateX(20px);
+}
+
 .link{ color:#8ab4ff; text-decoration:none; }
 .link:hover{ text-decoration:underline; }
 .trip-edit{ cursor:pointer; text-decoration:underline; }


### PR DESCRIPTION
## Summary
- replace theme button with toggle switch and update logic
- style theme switch for dark and light modes

## Testing
- `node fmtDate.test.js`
- `node tripValidation.test.js`
- `node backend.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4c5c71870832b9fdb966d9ce2989e