### PR TITLE
Move filter bar above view menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,6 @@
   </div>
 
   <main class="container">
-    <nav class="top-menu">
-      <button id="generalMenu" class="top-btn">📋 General</button>
-      <button id="dailyMenu" class="top-btn">📅 Cargas Diarias</button>
-      <button id="deliveryMenu" class="top-btn">🚚 Entregas hoy</button>
-      <button id="nlarMenu" class="top-btn">🏭 Inventario Nlar</button>
-    </nav>
     <section class="controls">
       <label for="statusFilter">Estatus:</label>
       <select id="statusFilter">
@@ -75,6 +69,12 @@
       <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
       <div id="bulkUploadStatus" class="upload-status"></div>
     </section>
+    <nav class="top-menu">
+      <button id="generalMenu" class="top-btn">📋 General</button>
+      <button id="dailyMenu" class="top-btn">📅 Cargas Diarias</button>
+      <button id="deliveryMenu" class="top-btn">🚚 Entregas hoy</button>
+      <button id="nlarMenu" class="top-btn">🏭 Inventario Nlar</button>
+    </nav>
 
     <section class="table-wrap">
       <table id="loadsTable">

--- a/styles.css
+++ b/styles.css
@@ -136,7 +136,7 @@ body{
 .controls{
   display:flex; flex-wrap:wrap; gap:10px; align-items:center;
   background: var(--panel); color:var(--text);
-  padding: 14px; border-radius: 14px;
+  padding: 14px; border-radius: 14px; margin:14px 0;
   box-shadow: 0 8px 26px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
 }
 .controls label{


### PR DESCRIPTION
## Summary
- Display filter controls above the view menu for better layout
- Add margin around filter controls to separate them from header and navigation

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4c85407ec832bb52e69ea7e4b4f14