### PR TITLE
Attach active view tab to table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -197,10 +197,10 @@ body{
 .table-wrap {
   flex:1;
   overflow:auto;
-  margin-top:14px;
+  margin-top:0;
   background: var(--panel-2);
   padding: 0 0 12px;
-  border-radius: 14px;
+  border-radius: 0 14px 14px 14px;
   box-shadow: 0 8px 26px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.05);
   width: 100%;
   min-height:0;
@@ -413,19 +413,24 @@ body{
 .top-menu{
   display:flex;
   gap:10px;
-  margin:0 0 14px;
+  margin:0;
 }
 .top-btn{
   background:var(--panel);
   border:0;
   color:var(--text);
   padding:10px 14px;
-  border-radius:12px;
+  border-radius:12px 12px 0 0;
   font-weight:600;
   cursor:pointer;
+  position:relative;
 }
 .top-btn:hover{ background:var(--panel-2); }
-.top-btn.active{ background: var(--accent); color:#fff; }
+.top-btn.active{
+  background: var(--panel-2);
+  color:var(--text);
+  margin-bottom:-1px;
+}
 
 /* Consistent font size for menu and filters */
 .top-btn,


### PR DESCRIPTION
## Summary
- Style active view tab to sit flush with the loads table
- Remove extra spacing between top menu and table to mimic browser-style tabs

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4cf325bcc832b813be89fd5fa2637