### PR TITLE
Use PNG for WhatsApp action icon

### DIFF
--- a/app.js
+++ b/app.js
@@ -701,7 +701,7 @@ function renderRows(rows, hiddenCols=[]){
     waLink.href = buildWaShareUrl(r);
     waLink.title = 'WhatsApp';
     const waImg = document.createElement('img');
-    waImg.src = 'assets/WP-logo.svg';
+    waImg.src = 'assets/WP-logo.png';
     waImg.alt = 'WhatsApp';
     waLink.appendChild(waImg);
     actionTd.appendChild(waLink);


### PR DESCRIPTION
## Summary
- switch WhatsApp action button to use WP-logo.png

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4e3777328832b8708cb9421c016af