### PR TITLE
Expand action icon without border

### DIFF
--- a/app.js
+++ b/app.js
@@ -695,7 +695,7 @@ function renderRows(rows, hiddenCols=[]){
     actionTd.appendChild(copyBtn);
 
     const waLink = document.createElement('a');
-    waLink.className = 'btn-mini';
+    waLink.className = 'btn-icon';
     waLink.target = '_blank';
     waLink.rel = 'noopener';
     waLink.href = buildWaShareUrl(r);

--- a/styles.css
+++ b/styles.css
@@ -274,6 +274,17 @@ body{
   width:20px; height:20px;
 }
 
+/* Icon button without borders */
+.btn-icon{
+  display:inline-block;
+  width:32px; height:32px;
+  padding:0; border:none; background:none; cursor:pointer;
+  border-radius:8px; overflow:hidden;
+}
+.btn-icon img{
+  width:100%; height:100%; display:block;
+}
+
 /* ====== Theme Switch ====== */
 .theme-switch{
   display:flex;


### PR DESCRIPTION
## Summary
- Add `btn-icon` style for borderless action icons
- Use new style on WhatsApp action to let the icon fill the action area

## Testing
- `node backend.test.js`
- `node fmtDate.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4e543b1d4832b9bfd8edb64b9249d