### PR TITLE
Use transparent background for copy icon

### DIFF
--- a/app.js
+++ b/app.js
@@ -687,7 +687,7 @@ function renderRows(rows, hiddenCols=[]){
     actionTd.className = 'action-bar';
 
     const copyBtn = document.createElement('button');
-    copyBtn.className = 'btn-mini';
+    copyBtn.className = 'btn-icon';
     copyBtn.dataset.act = 'copy';
     copyBtn.dataset.trip = r[COL.trip];
     const copyImg = document.createElement('img');


### PR DESCRIPTION
## Summary
- display copy action using the icon-only button style so it has no background

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4ebce1ed8832b8fddc9839ae27d1a