### PR TITLE
Use PNG WP-logo for WhatsApp action icon

### DIFF
--- a/app.js
+++ b/app.js
@@ -704,7 +704,7 @@ function renderRows(rows, hiddenCols=[]){
     waLink.href = buildWaShareUrl(r);
     waLink.title = 'WhatsApp';
     const waImg = document.createElement('img');
-    waImg.src = 'assets/whatsapp.svg';
+    waImg.src = 'assets/WP-logo.png';
     waImg.alt = 'WhatsApp';
     waLink.appendChild(waImg);
     actionTd.appendChild(waLink);


### PR DESCRIPTION
## Summary
- display WhatsApp action button with `assets/WP-logo.png` instead of the former SVG

## Testing
- `node fmtDate.test.js`
- `node backend.test.js`
- `node tripValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4f1f7e264832bb27e45bb6a0b77f7