### PR TITLE
Add demo credentials to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .env
-secure-config.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Aplicación PWA para seguimiento de cargas en tiempo real, conectada a Google Sh
 
 ## Configuración
 - URL de Google Apps Script: defínela en `config.js`.
-- Usuarios autorizados y el token de API deben provenir de un backend seguro.
+- Usuarios autorizados y token de API están versionados en `secure-config.json`.
 - Nombre de la hoja: `Tabla_1`
 - Columnas esperadas:
   - Trip, Caja, Referencia, Cliente, Destino, Estatus, Segmento, TR-MX, TR-USA, Cita carga, Llegada carga, Cita entrega, Llegada entrega, Comentarios, Docs, Tracking
@@ -33,28 +33,18 @@ export API_BASE="https://tu-web-app.example.com"
 echo "window.APP_CONFIG = { API_BASE: '${API_BASE}' };" > config.js
 ```
 
-Los valores sensibles (`AUTH_USERS`, `API_TOKEN`) deben servirse desde un
-endpoint protegido (por ejemplo `/secure-config.json`) o inyectarse mediante
-variables de entorno en el backend. El archivo `secure-config.sample.json`
-proporciona la estructura esperada pero no contiene datos reales.
+El archivo `secure-config.json` incluido en el repositorio expone credenciales
+de ejemplo para desarrollo o demostraciones. Si necesitas cambiarlas, edita
+los valores de `AUTH_USERS` y `API_TOKEN` directamente en ese archivo y
+asegúrate de replicarlos en el Web App de Google Apps Script.
 
 ### Distribución del token `API_TOKEN`
 
-1. **Google Apps Script**: en el editor de Apps Script ve a *Project Settings* 
-   y agrega una *Script property* llamada `API_TOKEN`. El código del Web App 
-   lo leerá con `PropertiesService.getScriptProperties().getProperty('API_TOKEN')` 
-   para validar las peticiones entrantes.
-2. **Endpoint de configuración**: el servidor que expone `/secure-config.json` 
-   debe leer el mismo valor desde la variable de entorno `API_TOKEN` e incluirlo 
-   en la respuesta junto con los usuarios autorizados.
-3. **Despliegue**: durante el despliegue genera el token una sola vez y 
-   distribúyelo tanto a las *Script properties* como a la variable de entorno 
-   del servidor. Ningún token debe mantenerse en el repositorio.
-
-Para desarrollo puedes ejecutar el endpoint localmente:
-
-```bash
-AUTH_USERS_JSON='[{"user":"demo","password":"secret"}]' \
-API_TOKEN="mi-token" node scripts/secure-config-server.js
-```
+1. **Google Apps Script**: en el editor de Apps Script ve a *Project Settings*
+   y agrega una *Script property* llamada `API_TOKEN` con el mismo valor que
+   aparece en `secure-config.json`.
+2. **Aplicación**: el archivo `config.js` ya apunta a `secure-config.json`,
+   por lo que la PWA leerá los usuarios y el token directamente del repositorio.
+3. **Actualizaciones**: si modificas las credenciales, recuerda actualizar las
+   propiedades del script para que coincidan.
 

--- a/config.js
+++ b/config.js
@@ -3,9 +3,6 @@
 window.APP_CONFIG = {
   // URL del Web App de Google Apps Script.
   API_BASE: 'https://script.google.com/macros/s/AKfycbyDBNKnJgRyUqWTOEI8rbLQalgLQp6HSOaOIDw60QecSinQtZUtCUgdkGQwpiNV8nd0/exec',
-  // Endpoint seguro que expone AUTH_USERS y API_TOKEN.
-  SECURE_CONFIG_URL: ''
+  // Archivo local con los usuarios autorizados y el token de API.
+  SECURE_CONFIG_URL: 'secure-config.json'
 };
-
-// Valores sensibles como AUTH_USERS y API_TOKEN deben obtenerse desde un
-// backend seguro o inyectarse como variables de entorno en el despliegue.

--- a/secure-config.json
+++ b/secure-config.json
@@ -1,0 +1,7 @@
+{
+  "AUTH_USERS": [
+    { "user": "demo", "password": "demo123" },
+    { "user": "operaciones", "password": "transporte2024" }
+  ],
+  "API_TOKEN": "demo-api-token-123456"
+}


### PR DESCRIPTION
## Summary
- add a committed `secure-config.json` with demo users and API token for quick setup
- point the app configuration at the bundled credentials and explain their usage in the README
- allow the tracked credentials file by updating `.gitignore`

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8589df774832baa52b595fe6ff145