### PR TITLE
Require login before loading app content

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Aplicación PWA para seguimiento de cargas en tiempo real, conectada a Google Sh
 ## Configuración
 - URL de Google Apps Script: defínela en `config.js` o establece `API_BASE` como variable de entorno.
 - Token de API: proporciónalo mediante `secure-config.json` (no versionado) o con la variable de entorno `API_TOKEN`/un endpoint seguro.
+- Usuarios permitidos: define un arreglo `users` dentro de `secure-config.json` (o en la respuesta del endpoint seguro) con objetos `{ "username": "...", "password": "...", "displayName": "..." }` para limitar quién puede acceder. Si omites la lista se permitirá cualquier combinación de usuario/contraseña tras enviar el formulario.
 - Nombre de la hoja: `Tabla_1`
 - Columnas esperadas:
   - Trip, Caja, Referencia, Cliente, Destino, Estatus, Segmento, TR-MX, TR-USA, Cita carga, Llegada carga, Cita entrega, Llegada entrega, Comentarios, Docs, Tracking

--- a/index.html
+++ b/index.html
@@ -36,83 +36,88 @@
         <button type="submit" class="btn">Iniciar sesión</button>
       </form>
     </section>
-    <div id="secureConfigMessage" role="alert" aria-live="assertive" hidden>
-      <p id="secureConfigMessageText"></p>
-      <form id="secureConfigForm" class="secure-config-form">
-        <label for="secureConfigToken">Token de API</label>
-        <input id="secureConfigToken" type="password" autocomplete="off" spellcheck="false" />
-        <div class="secure-config-actions">
-          <button type="submit" class="btn-mini">Guardar token</button>
-          <button type="button" id="secureConfigClear" class="btn-mini">Borrar token</button>
+
+    <div id="appContent" class="app-content" hidden>
+      <div id="secureConfigMessage" role="alert" aria-live="assertive" hidden>
+        <p id="secureConfigMessageText"></p>
+        <form id="secureConfigForm" class="secure-config-form">
+          <label for="secureConfigToken">Token de API</label>
+          <input id="secureConfigToken" type="password" autocomplete="off" spellcheck="false" />
+          <div class="secure-config-actions">
+            <button type="submit" class="btn-mini">Guardar token</button>
+            <button type="button" id="secureConfigClear" class="btn-mini">Borrar token</button>
+          </div>
+          <p class="secure-config-hint">El token se almacenará solo en este dispositivo.</p>
+        </form>
+      </div>
+
+      <section class="controls">
+        <label for="statusFilter">Estatus:</label>
+        <select id="statusFilter">
+          <option value="">Todos</option>
+        </select>
+
+        <label for="ejecutivoFilter">Ejecutivo:</label>
+        <select id="ejecutivoFilter">
+          <option value="">Todos</option>
+        </select>
+
+        <label for="searchBox">Buscar:</label>
+        <div class="search-wrapper">
+          <input id="searchBox" type="text" placeholder="Trip, Caja, Cliente, Destino"/>
+          <button id="clearSearch" type="button" class="clear-search" aria-label="Limpiar búsqueda">×</button>
         </div>
-        <p class="secure-config-hint">El token se almacenará solo en este dispositivo.</p>
-      </form>
+
+        <label for="startDate">Cita carga</label>
+        <div class="date-range">
+          <input type="date" id="startDate"/>
+          <span class="date-separator">→</span>
+          <input type="date" id="endDate"/>
+        </div>
+
+        <button id="refreshBtn" class="btn">Actualizar</button>
+        <button id="addBtn" class="btn" type="button">Agregar</button>
+        <input type="file" id="bulkUpload" accept=".xlsx,.csv"/>
+        <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
+        <div id="bulkUploadStatus" class="upload-status"></div>
+      </section>
+
+      <nav class="top-menu">
+        <button id="generalMenu" class="top-btn">📋 General</button>
+        <button id="dailyMenu" class="top-btn">📅 Cargas Diarias</button>
+        <button id="weeklyMenu" class="top-btn">🗓️ Programa semanal</button>
+        <button id="deliveryMenu" class="top-btn">🚚 Entregas hoy</button>
+        <button id="nlarMenu" class="top-btn">🏭 Inventario Nlar</button>
+      </nav>
+
+      <section class="table-wrap">
+        <table id="loadsTable">
+          <thead>
+            <tr>
+              <th>Ejecutivo</th>
+              <th>Trip</th>
+              <th>Caja</th>
+              <th>Referencia</th>
+              <th>Cliente</th>
+              <th>Destino</th>
+              <th>Estatus</th>
+              <th>Segmento</th>
+              <th>TR-MX</th>
+              <th>TR-USA</th>
+              <th>Cita carga</th>
+              <th>Llegada carga</th>
+              <th>Cita entrega</th>
+              <th>Llegada entrega</th>
+              <th>Comentarios</th>
+              <th>Docs</th>
+              <th>Tracking</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
     </div>
-    <section class="controls">
-      <label for="statusFilter">Estatus:</label>
-      <select id="statusFilter">
-        <option value="">Todos</option>
-      </select>
-
-      <label for="ejecutivoFilter">Ejecutivo:</label>
-      <select id="ejecutivoFilter">
-        <option value="">Todos</option>
-      </select>
-
-      <label for="searchBox">Buscar:</label>
-      <div class="search-wrapper">
-        <input id="searchBox" type="text" placeholder="Trip, Caja, Cliente, Destino"/>
-        <button id="clearSearch" type="button" class="clear-search" aria-label="Limpiar búsqueda">×</button>
-      </div>
-
-      <label for="startDate">Cita carga</label>
-      <div class="date-range">
-        <input type="date" id="startDate"/>
-        <span class="date-separator">→</span>
-        <input type="date" id="endDate"/>
-      </div>
-
-      <button id="refreshBtn" class="btn">Actualizar</button>
-      <button id="addBtn" class="btn" type="button">Agregar</button>
-      <input type="file" id="bulkUpload" accept=".xlsx,.csv"/>
-      <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
-      <div id="bulkUploadStatus" class="upload-status"></div>
-    </section>
-    <nav class="top-menu">
-      <button id="generalMenu" class="top-btn">📋 General</button>
-      <button id="dailyMenu" class="top-btn">📅 Cargas Diarias</button>
-      <button id="weeklyMenu" class="top-btn">🗓️ Programa semanal</button>
-      <button id="deliveryMenu" class="top-btn">🚚 Entregas hoy</button>
-      <button id="nlarMenu" class="top-btn">🏭 Inventario Nlar</button>
-    </nav>
-
-    <section class="table-wrap">
-      <table id="loadsTable">
-        <thead>
-          <tr>
-            <th>Ejecutivo</th>
-            <th>Trip</th>
-            <th>Caja</th>
-            <th>Referencia</th>
-            <th>Cliente</th>
-            <th>Destino</th>
-            <th>Estatus</th>
-            <th>Segmento</th>
-            <th>TR-MX</th>
-            <th>TR-USA</th>
-            <th>Cita carga</th>
-            <th>Llegada carga</th>
-            <th>Cita entrega</th>
-            <th>Llegada entrega</th>
-            <th>Comentarios</th>
-            <th>Docs</th>
-            <th>Tracking</th>
-            <th>Acciones</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </section>
   </main>
 
   <div id="addModal" class="modal">

--- a/secure-config.example.json
+++ b/secure-config.example.json
@@ -1,3 +1,10 @@
 {
-  "API_TOKEN": "YOUR_TOKEN_HERE"
+  "API_TOKEN": "YOUR_TOKEN_HERE",
+  "users": [
+    {
+      "username": "admin",
+      "password": "admin123",
+      "displayName": "Administrador"
+    }
+  ]
 }

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,14 @@ body{
   padding:10px 18px;
 }
 
+.app-content{
+  display:flex;
+  flex-direction:column;
+  flex:1;
+  min-height:0;
+  overflow:hidden;
+}
+
 .theme-light .login-panel{
   box-shadow:0 8px 24px rgba(15,44,92,0.15), inset 0 0 1px rgba(15,44,92,0.1);
 }


### PR DESCRIPTION
## Summary
- hide the dashboard until the login form is submitted and gate app bootstrapping behind a new authentication flow
- add optional credential parsing from secure-config users and expose helper utilities to reuse stored configuration
- update the UI markup/CSS to wrap authenticated sections, document the new behaviour, and extend the secure-config example

## Testing
- node fmtDate.test.js
- node backend.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8a54afd7c832b830578f3690d41a5