### PR TITLE
Send HTTP status through response headers

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -15,16 +15,18 @@ function isAuthorized(e) {
 }
 
 function createJsonOutput(payload, status) {
-  if (typeof status === 'number') {
-    payload = Object(payload);
-    payload.status = status;
-  }
-  return ContentService.createTextOutput()
+  var output = ContentService.createTextOutput()
     .setContent(JSON.stringify(payload))
     .setMimeType(ContentService.MimeType.JSON)
     .setHeader('Access-Control-Allow-Origin', '*')
     .setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
     .setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+
+  if (typeof status === 'number') {
+    output.setHeader('X-Http-Status-Code-Override', String(status));
+  }
+
+  return output;
 }
 
 function doPost(e) {


### PR DESCRIPTION
## Summary
- send HTTP status via the X-Http-Status-Code-Override header whenever createJsonOutput receives a numeric status code
- stop mutating the JSON payload with status information
- update backend tests to assert the header-based status and cover an unauthorized GET response

## Testing
- node backend.test.js
- node fmtDate.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8b12b8170832b9e79cf21c6460f93