### PR TITLE
Add constant-time authorization helper

### DIFF
--- a/backend.test.js
+++ b/backend.test.js
@@ -66,3 +66,6 @@ const result = doPost(e);
 const payload = JSON.parse(result.content);
 assert.strictEqual(payload.error, 'Trip column not found');
 console.log('Trip column missing test passed.');
+assert.strictEqual(originalIsAuthorized({ headers: { Authorization: 'Bearer demo-toke' } }), false, 'Tokens with mismatched length should be rejected.');
+assert.strictEqual(originalIsAuthorized({ parameter: { token: 'demo-tokem' } }), false, 'Wrong tokens should be rejected.');
+console.log('Authorization edge cases test passed.');

--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -2,6 +2,23 @@ const SHEET_NAME = 'Tabla_1';
 const AUTH_TOKEN = PropertiesService.getScriptProperties().getProperty('API_TOKEN');
 const SPREADSHEET_ID = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms';
 
+function secureCompare(a, b) {
+  if (typeof a !== 'string') {
+    a = a == null ? '' : String(a);
+  }
+  if (typeof b !== 'string') {
+    b = b == null ? '' : String(b);
+  }
+  var len = Math.max(a.length, b.length);
+  var mismatch = a.length ^ b.length;
+  for (var i = 0; i < len; i++) {
+    var aCode = i < a.length ? a.charCodeAt(i) : 0;
+    var bCode = i < b.length ? b.charCodeAt(i) : 0;
+    mismatch |= aCode ^ bCode;
+  }
+  return mismatch === 0;
+}
+
 function isAuthorized(e) {
   var headerToken = '';
   if (e && e.headers) {
@@ -11,7 +28,7 @@ function isAuthorized(e) {
     }
   }
   var paramToken = e.parameter && e.parameter.token;
-  return headerToken === AUTH_TOKEN || paramToken === AUTH_TOKEN;
+  return secureCompare(headerToken, AUTH_TOKEN) || secureCompare(paramToken, AUTH_TOKEN);
 }
 
 function createJsonOutput(payload, status) {


### PR DESCRIPTION
## Summary
- add a secure comparison helper to avoid timing attacks and update the authorization check to use it
- extend backend tests to assert unauthorized responses for mismatched-length and incorrect tokens

## Testing
- node backend.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8b1386e1c832b9bdf290f1352ff64