### PR TITLE
Fix data load during bootstrap

### DIFF
--- a/app.js
+++ b/app.js
@@ -1263,9 +1263,19 @@ function renderCurrent(){
 }
 
 async function main(){
+  const initialData = await fetchData();
+  const canRenderData = !lastFetchUnauthorized && !lastFetchErrorMessage;
+
+  if(canRenderData){
+    cache = initialData;
+  }
+
   populateStatusFilter(cache);
   populateEjecutivoFilter(cache);
-  renderDaily(cache);
+
+  if(canRenderData){
+    renderDaily(cache);
+  }
 
   fillStatusSelect($('#addForm select[name="estatus"]'), '', true);
 


### PR DESCRIPTION
## Summary
- fetch the initial dataset when bootstrapping the UI so the table populates after login
- only render the daily view when the initial fetch succeeds to avoid hiding error messages

## Testing
- node fmtDate.test.js
- node backend.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8b3a7c320832b89f489c4ec147460