### PR TITLE
Skip caching cross-origin requests in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -43,6 +43,11 @@ self.addEventListener('fetch', e => {
   }
 
   const url = new URL(request.url);
+
+  if (url.origin !== self.location.origin) {
+    e.respondWith(fetch(request));
+    return;
+  }
   if (url.pathname.endsWith('/config.js')) {
     e.respondWith(fetch(request));
     return;


### PR DESCRIPTION
## Summary
- prevent the service worker fetch handler from caching requests to external origins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8bc555150832ba4a4277f4a1dcf34