### PR TITLE
Configure Apps Script base URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@
     return '';
   };
 
+  // URL predeterminada del Web App activo de Apps Script.
   const DEFAULT_API_BASE = 'https://script.google.com/macros/s/AKfycbwLoaOwsPTv5bXdFxx75lGfKEaeptsBrHHVG_hKTuO_PN1G5RtsUOxvW7cLF9J1L4dz/exec';
 
   const apiBase = readEnvValue('API_BASE') || DEFAULT_API_BASE;


### PR DESCRIPTION
## Summary
- document and set the default Apps Script web app URL used by the client configuration

## Testing
- node backend.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8c6812928832badd24953a4ba7c8f