### PR TITLE
Implement offline queue and sync status indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
         <input type="file" id="bulkUpload" accept=".xlsx,.csv"/>
         <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
         <div id="bulkUploadStatus" class="upload-status"></div>
+        <div id="syncStatus" class="sync-status" role="status" aria-live="polite" aria-atomic="true" hidden></div>
       </section>
 
       <nav class="top-menu">

--- a/styles.css
+++ b/styles.css
@@ -357,6 +357,67 @@ body:not(.is-authenticated) .login-form{
 .theme-light .clear-search{
   color:#000;
 }
+
+.sync-status{
+  width:100%;
+  margin-top:6px;
+  padding:8px 12px;
+  border-radius:12px;
+  font-size:.9rem;
+  border:1px solid rgba(255,255,255,0.18);
+  background:rgba(37,99,235,0.14);
+  color:var(--text);
+  transition:background-color .2s ease, border-color .2s ease, color .2s ease;
+}
+
+.sync-status[data-state="idle"]{
+  border-color:rgba(22,163,74,0.45);
+  background:rgba(22,163,74,0.16);
+}
+
+.sync-status[data-state="offline"],
+.sync-status[data-state="queued"]{
+  border-color:rgba(245,158,11,0.5);
+  background:rgba(245,158,11,0.18);
+}
+
+.sync-status[data-state="syncing"]{
+  border-color:rgba(37,99,235,0.5);
+  background:rgba(37,99,235,0.18);
+}
+
+.sync-status[data-state="error"]{
+  border-color:rgba(239,68,68,0.55);
+  background:rgba(239,68,68,0.2);
+}
+
+.theme-light .sync-status{
+  border-color:rgba(148,163,184,0.5);
+  background:rgba(191,219,254,0.4);
+}
+
+.theme-light .sync-status[data-state="idle"]{
+  border-color:rgba(22,163,74,0.5);
+  background:rgba(22,163,74,0.12);
+}
+
+.theme-light .sync-status[data-state="offline"],
+.theme-light .sync-status[data-state="queued"]{
+  border-color:rgba(245,158,11,0.5);
+  background:rgba(254,240,138,0.5);
+}
+
+.theme-light .sync-status[data-state="syncing"]{
+  border-color:rgba(37,99,235,0.5);
+  background:rgba(191,219,254,0.65);
+}
+
+.theme-light .sync-status[data-state="error"]{
+  border-color:rgba(239,68,68,0.55);
+  background:rgba(254,202,202,0.7);
+  color:#7f1d1d;
+}
+
 .btn{
   background:var(--accent); color:#fff; border:0; border-radius:12px;
   padding:10px 14px; cursor:pointer; font-weight:600;


### PR DESCRIPTION
## Summary
- queue add/update requests in IndexedDB when offline and process them once connectivity returns
- add a visual sync status indicator so users know when operations are pending or syncing
- refactor record submission helpers and toast messaging for the new offline workflow

## Testing
- node fmtDate.test.js
- node backend.test.js
- node bulkAddDuplicates.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c99b26a838832bb5bc353f619966c2