### PR TITLE
Force immediate activation for updated service workers

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -15,7 +15,10 @@ const ASSET_URLS = ASSETS.map(a => new URL(a, self.location).pathname);
 
 self.addEventListener('install', e => {
   e.waitUntil(
-    caches.open(CACHE_NAME).then(c => c.addAll(ASSETS))
+    caches
+      .open(CACHE_NAME)
+      .then(c => c.addAll(ASSETS))
+      .then(() => self.skipWaiting())
   );
 });
 
@@ -25,7 +28,7 @@ self.addEventListener('activate', e => {
       Promise.all(
         keys.filter(k => ![CACHE_NAME, DYNAMIC_CACHE].includes(k)).map(k => caches.delete(k))
       )
-    )
+    ).then(() => self.clients.claim())
   );
 });
 


### PR DESCRIPTION
## Summary
- ensure the service worker calls `skipWaiting` once the static cache is populated so the new version can activate right away
- claim existing clients after cache cleanup during the activate event so the new worker controls open tabs immediately

## Testing
- not run (CLI environment lacks browser to validate service worker lifecycle)


------
https://chatgpt.com/codex/tasks/task_e_68c9a160cb38832bae7191f88ef25cc0