### PR TITLE
Adjust table columns to fit content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -467,6 +467,7 @@ body:not(.is-authenticated) .login-form{
   border-collapse:separate;
   border-spacing:0;
   background: transparent; color: var(--text);
+  table-layout:auto;
 }
 #loadsTable thead th{
   position: sticky; top:0;
@@ -492,8 +493,7 @@ body:not(.is-authenticated) .login-form{
   vertical-align: middle;
   font-size:.85rem;
   line-height: 1.4;
-  word-break: break-word;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
 }
 
 #loadsTable tbody tr td:first-child{
@@ -519,8 +519,6 @@ body:not(.is-authenticated) .login-form{
 
 #loadsTable th{
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* ====== Badges ====== */


### PR DESCRIPTION
## Summary
- ensure the loads table uses automatic column widths and keeps cell content on a single line
- allow headers to expand with their text by removing overflow clipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca29819568832bb08a842884201fda