### PR TITLE
Improve API CORS handling for record sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -1289,11 +1289,26 @@ async function sendRecordRequest(action, data){
 
   const token = SECURE_CONFIG.apiToken || '';
   const payload = { action, ...data };
-  const body = createApiFormBody(payload, token);
+  const bodyParams = createApiFormBody(payload, token);
+  const bodyString = typeof bodyParams.toString === 'function'
+    ? bodyParams.toString()
+    : String(bodyParams || '');
+  const url = buildApiUrlWithToken(API_BASE, token);
 
   let res;
   try{
-    res = await fetch(API_BASE, { method:'POST', body });
+    res = await fetch(url, {
+      method:'POST',
+      body: bodyString,
+      mode:'cors',
+      redirect:'follow',
+      credentials:'omit',
+      cache:'no-store',
+      headers:{
+        'Content-Type':'application/x-www-form-urlencoded;charset=UTF-8',
+        'Accept':'application/json'
+      }
+    });
   }catch(err){
     if(isLikelyNetworkError(err)){
       const networkError = new Error('No se pudo conectar con el servicio.');


### PR DESCRIPTION
## Summary
- normalize incoming request origins in the Apps Script backend and echo them in the CORS headers
- ensure OPTIONS responses share the same CORS metadata with a cache duration
- send POST requests from the PWA with explicit CORS-aware fetch options and headers

## Testing
- node backend.test.js
- node backend/Code.test.js
- node bulkAddDuplicates.test.js
- node fmtDate.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cac79c8dec832bbbefa4f7df8db572