### PR TITLE
Restringe operaciones offline y agrega aviso bloqueante

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -803,6 +803,18 @@ body:not(.is-authenticated) .login-form{
   overflow-y:auto;
   flex:1;
 }
+#syncBlockingModal .modal-content{
+  width:min(360px, calc(100% - 40px));
+  text-align:center;
+}
+#syncBlockingModal .modal-content h2{
+  margin-bottom:12px;
+}
+#syncBlockingModal .modal-content p{
+  margin:0;
+  font-size:1rem;
+  line-height:1.5;
+}
 .modal-content h2{
   margin-top:0;
   font-size:calc(1.5rem - 2px);


### PR DESCRIPTION
## Summary
- impide que addRecord y updateRecord encolen solicitudes offline y muestran un modal de conexión cuando falta internet
- actualiza el manejo de formularios, carga masiva y cambio de estatus para exigir conexión y avisar al usuario
- agrega estilos para el modal bloqueante de sincronización

## Testing
- No se ejecutaron pruebas automatizadas (no se encontraron scripts de prueba)


------
https://chatgpt.com/codex/tasks/task_e_68cad1a5eab4832bb0cc91c4c40abda2