### PR TITLE
Short-circuit authorization when token is missing

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -20,6 +20,10 @@ function secureCompare(a, b) {
 }
 
 function isAuthorized(e) {
+  if (!AUTH_TOKEN) {
+    Logger.log('API token is not configured. Please set the API_TOKEN script property.');
+    return false;
+  }
   var headerToken = '';
   if (e && e.headers) {
     var authHeader = e.headers.Authorization || e.headers.authorization;


### PR DESCRIPTION
## Summary
- short-circuit authorization to immediately fail when the API token is not configured
- log a clear message so administrators know to set the API token property

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae299b350832bb0f25d1048254c07