### PR TITLE
Add UI flow to create new records

### DIFF
--- a/app.js
+++ b/app.js
@@ -2033,6 +2033,144 @@ async function main(){
     if(file) handleBulkUpload(file);
   });
 
+  const addRecordModal = $('#addRecordModal');
+  const addRecordForm = $('#addRecordForm');
+  const addRecordBtn = $('#addRecordBtn');
+  const cancelAddRecordBtn = $('#cancelAddRecord');
+  const addRecordStatusSelect = addRecordForm?.querySelector('select[name="estatus"]');
+
+  fillStatusSelect(addRecordStatusSelect, '', true);
+
+  addRecordBtn?.addEventListener('click', () => {
+    if(!addRecordModal || !addRecordForm) return;
+    addRecordForm.reset();
+    fillStatusSelect(addRecordStatusSelect, '', true);
+    addRecordModal.classList.add('show');
+    const tripInput = addRecordForm.querySelector('input[name="trip"]');
+    tripInput?.focus();
+  });
+
+  cancelAddRecordBtn?.addEventListener('click', () => {
+    addRecordForm?.reset();
+    addRecordModal?.classList.remove('show');
+  });
+
+  addRecordForm?.addEventListener('submit', async ev => {
+    ev.preventDefault();
+    if(!addRecordForm) return;
+
+    const submitBtn = addRecordForm.querySelector('button[type="submit"]');
+    if(submitBtn) submitBtn.disabled = true;
+
+    try{
+      const formData = new FormData(addRecordForm);
+      const getTrimmed = name => String(formData.get(name) ?? '').trim();
+
+      const trip = getTrimmed('trip');
+      const ejecutivo = getTrimmed('ejecutivo');
+      const caja = getTrimmed('caja');
+      const referencia = getTrimmed('referencia');
+      const cliente = getTrimmed('cliente');
+      const destino = getTrimmed('destino');
+      const estatus = getTrimmed('estatus');
+      const citaCargaRaw = getTrimmed('citaCarga');
+
+      const tripInput = addRecordForm.querySelector('input[name="trip"]');
+      const ejecutivoInput = addRecordForm.querySelector('input[name="ejecutivo"]');
+      const cajaInput = addRecordForm.querySelector('input[name="caja"]');
+      const referenciaInput = addRecordForm.querySelector('input[name="referencia"]');
+      const clienteInput = addRecordForm.querySelector('input[name="cliente"]');
+      const destinoInput = addRecordForm.querySelector('input[name="destino"]');
+      const estatusSelect = addRecordStatusSelect || addRecordForm.querySelector('select[name="estatus"]');
+      const citaCargaInput = addRecordForm.querySelector('input[name="citaCarga"]');
+
+      if(tripInput) tripInput.value = trip;
+      if(ejecutivoInput) ejecutivoInput.value = ejecutivo;
+      if(cajaInput) cajaInput.value = caja;
+      if(referenciaInput) referenciaInput.value = referencia;
+      if(clienteInput) clienteInput.value = cliente;
+      if(destinoInput) destinoInput.value = destino;
+
+      if(!trip){
+        toast('Proporciona un Trip válido', 'error');
+        tripInput?.focus();
+        return;
+      }
+      if(!validateTrip(trip)){
+        tripInput?.focus();
+        return;
+      }
+      if(!ejecutivo){
+        toast('Proporciona un Ejecutivo', 'error');
+        ejecutivoInput?.focus();
+        return;
+      }
+      if(!caja){
+        toast('Proporciona una Caja', 'error');
+        cajaInput?.focus();
+        return;
+      }
+      if(!referencia){
+        toast('Proporciona una Referencia', 'error');
+        referenciaInput?.focus();
+        return;
+      }
+      if(!cliente){
+        toast('Proporciona un Cliente', 'error');
+        clienteInput?.focus();
+        return;
+      }
+      if(!destino){
+        toast('Proporciona un Destino', 'error');
+        destinoInput?.focus();
+        return;
+      }
+      if(!estatus){
+        toast('Selecciona un Estatus', 'error');
+        estatusSelect?.focus();
+        return;
+      }
+
+      const citaCarga = toGASDate(citaCargaRaw);
+      if(!citaCarga){
+        toast('Proporciona una Cita carga válida', 'error');
+        citaCargaInput?.focus();
+        return;
+      }
+
+      const success = await addRecord({
+        trip,
+        ejecutivo,
+        caja,
+        referencia,
+        cliente,
+        destino,
+        estatus,
+        citaCarga
+      });
+
+      if(!success){
+        return;
+      }
+
+      const refreshed = await fetchData();
+      if(lastFetchUnauthorized){
+        return;
+      }
+
+      cache = refreshed;
+      populateStatusFilter(cache);
+      populateEjecutivoFilter(cache);
+      renderCurrent();
+
+      addRecordForm.reset();
+      fillStatusSelect(addRecordStatusSelect, '', true);
+      addRecordModal?.classList.remove('show');
+    }finally{
+      if(submitBtn) submitBtn.disabled = false;
+    }
+  });
+
   $('#cancelArrival').addEventListener('click', ()=>{
     $('#arrivalModal').classList.remove('show');
     $('#arrivalForm').reset();

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
         </div>
 
         <div class="controls__actions">
+          <button id="addRecordBtn" class="btn" type="button">Nuevo registro</button>
           <button id="refreshBtn" class="btn">Actualizar</button>
           <input type="file" id="bulkUpload" accept=".xlsx,.csv"/>
           <button id="bulkUploadBtn" class="btn" type="button">Carga masiva</button>
@@ -140,6 +141,42 @@
       </section>
     </div>
   </main>
+
+  <div id="addRecordModal" class="modal">
+    <div class="modal-content modal-content--form">
+      <h2>Agregar registro</h2>
+      <form id="addRecordForm">
+        <label>Trip
+          <input type="text" name="trip" inputmode="numeric" pattern="\d+" autocomplete="off" required />
+        </label>
+        <label>Ejecutivo
+          <input type="text" name="ejecutivo" autocomplete="off" required />
+        </label>
+        <label>Caja
+          <input type="text" name="caja" autocomplete="off" required />
+        </label>
+        <label>Referencia
+          <input type="text" name="referencia" autocomplete="off" required />
+        </label>
+        <label>Cliente
+          <input type="text" name="cliente" autocomplete="off" required />
+        </label>
+        <label>Destino
+          <input type="text" name="destino" autocomplete="off" required />
+        </label>
+        <label>Estatus
+          <select name="estatus" required></select>
+        </label>
+        <label>Cita carga
+          <input type="datetime-local" name="citaCarga" required lang="es-MX" />
+        </label>
+        <div class="modal-actions">
+          <button type="button" id="cancelAddRecord" class="btn-mini">Cancelar</button>
+          <button type="submit" class="btn">Guardar</button>
+        </div>
+      </form>
+    </div>
+  </div>
 
   <div id="arrivalModal" class="modal">
     <div class="modal-content">

--- a/styles.css
+++ b/styles.css
@@ -862,11 +862,20 @@ body:not(.is-authenticated) .login-form{
   z-index:1000;
 }
 .modal.show{ visibility:visible; opacity:1; }
-.modal-content{
+.modal-content{ 
   background:var(--panel); color:var(--text); padding:20px; border-radius:14px; width:300px;
   box-shadow:0 8px 26px rgba(0,0,0,.35);
   font-size:14px;
   overflow:hidden;
+}
+.modal-content--form{
+  width:min(420px, calc(100% - 40px));
+  max-height:90vh;
+  overflow-y:auto;
+}
+.modal-content--form form{
+  display:flex;
+  flex-direction:column;
 }
 #syncBlockingModal .modal-content{
   width:min(360px, calc(100% - 40px));


### PR DESCRIPTION
## Summary
- add a "Nuevo registro" control button that opens a modal for capturing trip information
- build a form that gathers Trip, Ejecutivo, Caja, Referencia, Cliente, Destino, Estatus y Cita carga and posts it through the existing addRecord flow
- style the modal container to comfortably fit the new form fields

## Testing
- node fmtDate.test.js
- node bulkAddDuplicates.test.js
- node tripValidation.test.js
- node backend.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cb3c7a5574832b8a1a624a5b161889