### PR TITLE
Add edit modal triggered from trip button

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,69 @@
     </div>
   </div>
 
+  <div id="editRecordModal" class="modal">
+    <div class="modal-content modal-content--form">
+      <h2>Editar registro</h2>
+      <form id="editRecordForm">
+        <label>Trip
+          <input type="text" name="trip" inputmode="numeric" pattern="\d+" autocomplete="off" required />
+        </label>
+        <label>Ejecutivo
+          <input type="text" name="ejecutivo" autocomplete="off" required />
+        </label>
+        <label>Caja
+          <input type="text" name="caja" autocomplete="off" required />
+        </label>
+        <label>Referencia
+          <input type="text" name="referencia" autocomplete="off" required />
+        </label>
+        <label>Cliente
+          <input type="text" name="cliente" autocomplete="off" required />
+        </label>
+        <label>Destino
+          <input type="text" name="destino" autocomplete="off" required />
+        </label>
+        <label>Estatus
+          <select name="estatus" required></select>
+        </label>
+        <label>Segmento
+          <input type="text" name="segmento" autocomplete="off" />
+        </label>
+        <label>TR-MX
+          <input type="text" name="trmx" autocomplete="off" />
+        </label>
+        <label>TR-USA
+          <input type="text" name="trusa" autocomplete="off" />
+        </label>
+        <label>Cita carga
+          <input type="datetime-local" name="citaCarga" required lang="es-MX" />
+        </label>
+        <label>Llegada carga
+          <input type="datetime-local" name="llegadaCarga" lang="es-MX" />
+        </label>
+        <label>Cita entrega
+          <input type="datetime-local" name="citaEntrega" lang="es-MX" />
+        </label>
+        <label>Llegada entrega
+          <input type="datetime-local" name="llegadaEntrega" lang="es-MX" />
+        </label>
+        <label>Comentarios
+          <input type="text" name="comentarios" autocomplete="off" />
+        </label>
+        <label>Docs
+          <input type="text" name="docs" autocomplete="off" />
+        </label>
+        <label>Tracking
+          <input type="text" name="tracking" autocomplete="off" />
+        </label>
+        <div class="modal-actions">
+          <button type="button" id="cancelEditRecord" class="btn-mini">Cancelar</button>
+          <button type="submit" class="btn">Guardar cambios</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
   <div id="arrivalModal" class="modal">
     <div class="modal-content">
       <h2>Llegada entrega</h2>

--- a/styles.css
+++ b/styles.css
@@ -666,6 +666,30 @@ body:not(.is-authenticated) .login-form{
 .action-bar{
   display:flex; flex-wrap:nowrap; gap:8px; align-items:center;
 }
+.trip-button{
+  background:none;
+  border:none;
+  color:var(--accent);
+  cursor:pointer;
+  font:inherit;
+  padding:0;
+  text-decoration:underline;
+  transition:color .2s ease, text-decoration-color .2s ease;
+}
+.trip-button:hover,
+.trip-button:focus-visible{
+  color:var(--accent-2);
+  text-decoration-thickness:2px;
+}
+.trip-button:focus-visible{
+  outline:2px solid var(--accent-2);
+  outline-offset:2px;
+}
+.trip-button:disabled{
+  color:var(--muted);
+  cursor:not-allowed;
+  text-decoration:none;
+}
 .btn-mini{
   background:#fff; color:#0d2360; border:1px solid #d1d5db;
   border-radius:8px; padding:6px 8px; font-size:.85rem; cursor:pointer;


### PR DESCRIPTION
## Summary
- add an edit modal that preloads record data and submits updates
- render each trip number as an edit button that opens the modal
- style the trip button for consistency with the existing UI

## Testing
- node fmtDate.test.js
- node bulkAddDuplicates.test.js
- node backend.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc13dde3b4832bbc18dcd2d5febd10