### PR TITLE
Remove row numbering column and expand table width

### DIFF
--- a/app.js
+++ b/app.js
@@ -654,11 +654,6 @@
       }
 
       const headerRow = doc.createElement('tr');
-      const cornerCell = doc.createElement('th');
-      cornerCell.className = 'row-number-header';
-      cornerCell.scope = 'col';
-      cornerCell.textContent = '';
-      headerRow.appendChild(cornerCell);
 
       for (let c = 0; c < columnCount; c++) {
         const th = doc.createElement('th');
@@ -676,11 +671,6 @@
       const fragment = doc.createDocumentFragment();
       rows.forEach(function (row, rowIndex) {
         const tr = doc.createElement('tr');
-        const rowHeader = doc.createElement('th');
-        rowHeader.className = 'row-number-cell';
-        rowHeader.scope = 'row';
-        rowHeader.textContent = String(rowIndex + 1);
-        tr.appendChild(rowHeader);
 
         for (let c = 0; c < columnCount; c++) {
           const td = doc.createElement('td');

--- a/styles.css
+++ b/styles.css
@@ -30,9 +30,9 @@ body {
 }
 
 .sheet-app {
-  width: min(1440px, 100%);
+  width: 100%;
   margin: 0 auto;
-  padding: 32px clamp(16px, 5vw, 48px) 48px;
+  padding: 32px clamp(16px, 3vw, 40px) 48px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -154,7 +154,6 @@ body {
 
 .sheet-table {
   width: 100%;
-  min-width: 1280px;
   border-collapse: separate;
   border-spacing: 0;
   font-size: 0.9rem;
@@ -178,22 +177,6 @@ body {
   font-weight: 600;
   color: var(--sheet-text);
   z-index: 2;
-}
-
-.sheet-table thead th:first-child {
-  left: 0;
-  z-index: 3;
-}
-
-.sheet-table tbody th {
-  background: var(--sheet-header-bg);
-  font-weight: 500;
-  text-align: right;
-  color: var(--sheet-text-soft);
-  position: sticky;
-  left: 0;
-  z-index: 1;
-  min-width: 56px;
 }
 
 .sheet-table tbody tr:nth-child(even) td {


### PR DESCRIPTION
## Summary
- remove the static row-number column from the rendered data table
- update layout styles so the sheet view stretches across the full width of the screen

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc4e7504a0832b9ee4a8902e453a14