### PR TITLE
Add daily loads view menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <div class="sheet-app__status" data-status aria-live="polite" hidden></div>
 
     <div class="sheet-grid">
+      <div class="sheet-grid__views" data-view-menu role="toolbar" aria-label="Vistas de la tabla"></div>
       <div class="sheet-grid__viewport" role="region" aria-live="polite" aria-label="Tabla de seguimiento">
         <table class="sheet-table">
           <thead data-table-head></thead>

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,54 @@ body {
   overflow: hidden;
 }
 
+.sheet-grid__views {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--sheet-border);
+  background: #fff;
+}
+
+.sheet-grid__views-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--sheet-text-soft);
+}
+
+.sheet-grid__view-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--sheet-text-soft);
+  font-size: 0.85rem;
+  font-weight: 500;
+  border-radius: 999px;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.sheet-grid__view-button:hover,
+.sheet-grid__view-button:focus {
+  border-color: rgba(26, 115, 232, 0.4);
+  color: var(--accent);
+  outline: none;
+}
+
+.sheet-grid__view-button.is-active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.sheet-grid__view-button.is-active:hover,
+.sheet-grid__view-button.is-active:focus {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+}
+
 .sheet-grid__viewport {
   width: 100%;
   overflow: auto;


### PR DESCRIPTION
## Summary
- add a table view selector above the grid with a default and "Cargas diarias" option
- filter sheet rows for "Cargas diarias" to show overdue or today loads with allowed statuses
- style the new view buttons to match the existing UI

## Testing
- node fmtDate.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc77b0c224832bb30e3d5c980e2153