### PR TITLE
Ordena la vista de cargas diarias por cita de carga

### DIFF
--- a/app.js
+++ b/app.js
@@ -854,10 +854,28 @@
         });
       }
 
-      if (dateColumnIndices.length > 0 && rowsToRender.length > 1) {
+      const sortColumnIndices = (function () {
+        if (dateColumnIndices.length === 0) {
+          return [];
+        }
+        const indices = dateColumnIndices.slice();
+        if (activeView && activeView.id === 'daily-loads') {
+          const citaCargaIndex = columnMap.citaCarga;
+          if (typeof citaCargaIndex === 'number' && citaCargaIndex >= 0) {
+            const filtered = indices.filter(function (value) {
+              return value !== citaCargaIndex;
+            });
+            filtered.unshift(citaCargaIndex);
+            return filtered;
+          }
+        }
+        return indices;
+      })();
+
+      if (sortColumnIndices.length > 0 && rowsToRender.length > 1) {
         const sortableEntries = rowsToRender.map(function (entry) {
           const row = Array.isArray(entry.row) ? entry.row : [];
-          const sortValues = dateColumnIndices.map(function (columnIndex) {
+          const sortValues = sortColumnIndices.map(function (columnIndex) {
             if (columnIndex >= row.length) {
               return Number.POSITIVE_INFINITY;
             }
@@ -870,7 +888,7 @@
         });
 
         sortableEntries.sort(function (a, b) {
-          for (let i = 0; i < dateColumnIndices.length; i++) {
+          for (let i = 0; i < sortColumnIndices.length; i++) {
             const aValue = a.sortValues[i];
             const bValue = b.sortValues[i];
             if (aValue < bValue) {


### PR DESCRIPTION
## Resumen
- prioriza la columna "Cita carga" al ordenar las filas en la vista de cargas diarias
- mantiene el comportamiento de ordenamiento para el resto de vistas sin cambios

## Pruebas
- node fmtDate.test.js
- node backend.test.js
- node bulkAddDuplicates.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc835bea80832bb3ac823bbe5b8986