### PR TITLE
Add new record creation flow

### DIFF
--- a/backend/Code.gs
+++ b/backend/Code.gs
@@ -106,27 +106,30 @@ function doPost(e) {
         if (String(data[i][tripIdx]) === trip) throw new Error('Trip already exists');
       }
       var citaCargaDate = p.citaCarga ? Utilities.parseDate(p.citaCarga, timeZone, "yyyy-MM-dd'T'HH:mm:ss") : '';
+      var llegadaCargaDate = p.llegadaCarga ? Utilities.parseDate(p.llegadaCarga, timeZone, "yyyy-MM-dd'T'HH:mm:ss") : '';
+      var citaEntregaDate = p.citaEntrega ? Utilities.parseDate(p.citaEntrega, timeZone, "yyyy-MM-dd'T'HH:mm:ss") : '';
+      var llegadaEntregaDate = p.llegadaEntrega ? Utilities.parseDate(p.llegadaEntrega, timeZone, "yyyy-MM-dd'T'HH:mm:ss") : '';
       var ejecutivo = (p.ejecutivo || p.Ejecutivo || '').trim();
       if (!ejecutivo) throw new Error('Missing ejecutivo');
       var row = new Array(headers.length).fill('');
       var map = {
         'Ejecutivo': ejecutivo,
         'Trip': trip,
-        'Caja': '',
+        'Caja': p.caja || '',
         'Referencia': p.referencia || '',
         'Cliente': p.cliente || '',
         'Destino': p.destino || '',
         'Estatus': p.estatus || '',
-        'Segmento': '',
-        'TR-MX': '',
-        'TR-USA': '',
+        'Segmento': p.segmento || '',
+        'TR-MX': p.trmx || '',
+        'TR-USA': p.trusa || '',
         'Cita carga': citaCargaDate,
-        'Llegada carga': '',
-        'Cita entrega': '',
-        'Llegada entrega': '',
-        'Comentarios': '',
-        'Docs': '',
-        'Tracking': ''
+        'Llegada carga': llegadaCargaDate,
+        'Cita entrega': citaEntregaDate,
+        'Llegada entrega': llegadaEntregaDate,
+        'Comentarios': p.comentarios || '',
+        'Docs': p.docs || '',
+        'Tracking': p.tracking || ''
       };
       for (var h in map) {
         var idx = headerMap[h.toLowerCase()];

--- a/backend/Code.test.js
+++ b/backend/Code.test.js
@@ -44,9 +44,21 @@ const e = {
     action: 'add',
     ejecutivo: 'Maria',
     trip: '225001',
+    caja: 'CJ1',
     referencia: 'R1',
     cliente: 'C1',
-    estatus: 'E1'
+    destino: 'D1',
+    estatus: 'E1',
+    segmento: 'S1',
+    trmx: 'MX1',
+    trusa: 'US1',
+    citaCarga: '2024-08-01T12:00:00',
+    llegadaCarga: '2024-08-02T01:30:00',
+    citaEntrega: '2024-08-03T09:15:00',
+    llegadaEntrega: '2024-08-04T17:45:00',
+    comentarios: 'Sin observaciones',
+    docs: 'DOCS',
+    tracking: 'TRK-1'
   }
 };
 
@@ -54,4 +66,20 @@ sandbox.doPost(e);
 
 const row = appendedRows[0];
 assert.strictEqual(row[0], 'Maria');
+assert.strictEqual(row[1], '225001');
+assert.strictEqual(row[2], 'CJ1');
+assert.strictEqual(row[3], 'R1');
+assert.strictEqual(row[4], 'C1');
+assert.strictEqual(row[5], 'D1');
+assert.strictEqual(row[6], 'E1');
+assert.strictEqual(row[7], 'S1');
+assert.strictEqual(row[8], 'MX1');
+assert.strictEqual(row[9], 'US1');
+assert.strictEqual(row[10], '2024-08-01T12:00:00');
+assert.strictEqual(row[11], '2024-08-02T01:30:00');
+assert.strictEqual(row[12], '2024-08-03T09:15:00');
+assert.strictEqual(row[13], '2024-08-04T17:45:00');
+assert.strictEqual(row[14], 'Sin observaciones');
+assert.strictEqual(row[15], 'DOCS');
+assert.strictEqual(row[16], 'TRK-1');
 console.log('Code.gs tests passed.');

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       <div class="sheet-app__controls">
         <button type="button" class="button" data-action="change-token">Cambiar token</button>
         <button type="button" class="button" data-action="refresh">Actualizar</button>
+        <button type="button" class="button button--primary" data-action="new-record">Nuevo registro</button>
         <button type="button" class="button button--secondary" data-action="logout">Cerrar sesión</button>
       </div>
     </header>
@@ -42,8 +43,8 @@
 
   <section class="edit-modal hidden" data-edit-modal aria-modal="true" role="dialog" aria-labelledby="editTitle">
     <form class="edit-modal__form" data-edit-form novalidate>
-      <h2 id="editTitle">Editar registro</h2>
-      <p class="edit-modal__hint">Actualiza la información del viaje y guarda los cambios.</p>
+      <h2 id="editTitle" data-edit-title>Editar registro</h2>
+      <p class="edit-modal__hint" data-edit-hint>Actualiza la información del viaje y guarda los cambios.</p>
       <div class="edit-modal__grid">
         <div class="form-field">
           <label for="editTrip">Trip</label>
@@ -117,7 +118,7 @@
       <p class="edit-modal__error" data-edit-error aria-live="assertive"></p>
       <div class="edit-modal__actions">
         <button type="button" class="button button--secondary" data-action="cancel-edit">Cancelar</button>
-        <button type="submit" class="button button--primary">Guardar cambios</button>
+        <button type="submit" class="button button--primary" data-edit-submit>Guardar cambios</button>
       </div>
     </form>
   </section>


### PR DESCRIPTION
## Summary
- add a toolbar button and modal state handling to create new records from the UI
- allow the Apps Script add action to persist all captured fields and update the backend unit test

## Testing
- node fmtDate.test.js
- node tripValidation.test.js
- node bulkAddDuplicates.test.js
- node backend.test.js
- node backend/Code.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc8dc650f8832baa96d9ac384e1f62