### PR TITLE
Limit date filter to cita carga column

### DIFF
--- a/app.js
+++ b/app.js
@@ -1276,13 +1276,15 @@
 
       const startTime = isValidDate(normalizedDateRange.start) ? normalizedDateRange.start.getTime() : null;
       const endTime = isValidDate(normalizedDateRange.end) ? normalizedDateRange.end.getTime() : null;
-      const hasDateRange = (startTime != null || endTime != null) && dateColumnIndices.length > 0;
+      const citaCargaIndex = typeof columnMap.citaCarga === 'number' && columnMap.citaCarga >= 0 ? columnMap.citaCarga : null;
+      const dateFilterIndices = citaCargaIndex != null ? [citaCargaIndex] : [];
+      const hasDateRange = (startTime != null || endTime != null) && dateFilterIndices.length > 0;
 
       if (hasDateRange) {
         rowsToRender = rowsToRender.filter(function (entry) {
           const row = Array.isArray(entry.row) ? entry.row : [];
-          for (let i = 0; i < dateColumnIndices.length; i++) {
-            const columnIndex = dateColumnIndices[i];
+          for (let i = 0; i < dateFilterIndices.length; i++) {
+            const columnIndex = dateFilterIndices[i];
             if (columnIndex >= row.length) {
               continue;
             }


### PR DESCRIPTION
## Summary
- limit the date range filtering logic to the Cita carga column
- leave other date columns unaffected by the date filter while keeping existing sorting behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc9c0c1104832b97b9ee7ce45ee172