### PR TITLE
Simplifica indicador de estado y elimina texto redundante

### DIFF
--- a/app.js
+++ b/app.js
@@ -853,14 +853,16 @@
       if (!el) return;
       if (!message) {
         el.textContent = '';
-        el.className = 'sheet-app__status';
+        el.className = 'sheet-status';
         el.hidden = true;
+        el.removeAttribute('title');
         return;
       }
-      const statusClass = 'sheet-app__status' + (type ? ` is-${type}` : '');
+      const statusClass = 'sheet-status' + (type ? ` is-${type}` : '');
       el.className = statusClass;
       el.hidden = false;
       el.textContent = message;
+      el.title = message;
     }
 
     function setEditModalMode(mode) {
@@ -1446,7 +1448,7 @@
       if (rowsToRender.length === 0) {
         setStatus('No hay registros para la vista seleccionada.', 'info');
       } else {
-        setStatus('Datos sincronizados correctamente.', 'success');
+        setStatus('Sincronizado', 'success');
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
     <header class="sheet-app__toolbar">
       <div class="sheet-app__title-group">
         <h1>Seguimiento de cargas</h1>
-        <p class="sheet-app__subtitle">Vista conectada directamente con la hoja de cálculo.</p>
       </div>
       <div class="sheet-app__controls">
         <button type="button" class="button is-hidden" data-action="change-token">Cambiar token</button>
@@ -20,8 +19,6 @@
         <button type="button" class="button button--secondary" data-action="logout">Cerrar sesión</button>
       </div>
     </header>
-
-    <div class="sheet-app__status" data-status aria-live="polite" hidden></div>
 
     <div class="sheet-grid">
       <div class="sheet-grid__views" data-view-menu role="toolbar" aria-label="Vistas de la tabla"></div>
@@ -90,6 +87,9 @@
 
     <footer class="sheet-app__footer">
       <span class="sheet-app__footer-item" data-last-updated>Última actualización: —</span>
+      <span class="sheet-app__footer-item sheet-app__footer-item--status">
+        <span class="sheet-status" data-status aria-live="polite" hidden></span>
+      </span>
       <span class="sheet-app__footer-item" data-current-user></span>
     </footer>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -53,12 +53,6 @@ body {
   letter-spacing: -0.015em;
 }
 
-.sheet-app__subtitle {
-  margin: 4px 0 0;
-  color: var(--sheet-text-soft);
-  font-size: 0.95rem;
-}
-
 .sheet-app__controls {
   display: flex;
   gap: 8px;
@@ -106,36 +100,46 @@ body {
   color: var(--sheet-text-soft);
 }
 
-.sheet-app__status {
-  min-height: 24px;
-  padding: 12px 16px;
-  border-radius: 10px;
-  border: 1px solid transparent;
-  font-size: 0.95rem;
-  background: #fff;
-  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.15);
+.sheet-app__footer-item--status {
+  min-width: 0;
 }
 
-.sheet-app__status[hidden] {
+.sheet-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.sheet-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+.sheet-status[hidden] {
   display: none;
 }
 
-.sheet-app__status.is-info {
-  border-color: rgba(26, 115, 232, 0.25);
+.sheet-status.is-info {
   color: var(--accent);
-  background: rgba(26, 115, 232, 0.08);
+  opacity: 1;
 }
 
-.sheet-app__status.is-success {
-  border-color: rgba(24, 128, 56, 0.25);
+.sheet-status.is-success {
   color: var(--success);
-  background: rgba(24, 128, 56, 0.08);
+  opacity: 1;
 }
 
-.sheet-app__status.is-error {
-  border-color: rgba(217, 48, 37, 0.25);
+.sheet-status.is-error {
   color: var(--danger);
-  background: rgba(217, 48, 37, 0.08);
+  opacity: 1;
 }
 
 .sheet-grid {


### PR DESCRIPTION
## Summary
- elimina la leyenda bajo el título principal de la aplicación para limpiar la cabecera
- reubica el indicador de estado en el pie de página con un estilo más compacto y discreto
- ajusta la lógica de estado para usar el nuevo contenedor y mostrar un mensaje de sincronización simplificado

## Testing
- No tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc9be2fb78832bbcd3d38e9144a0bc