### PR TITLE
Remove grid borders from sheet table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -669,7 +669,7 @@ body {
 .sheet-table thead th,
 .sheet-table tbody td,
 .sheet-table tbody th {
-  border: 1px solid var(--sheet-border);
+  border: none;
   padding: 10px 12px;
   line-height: 1.4;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- remove borders from sheet table cells so only content is displayed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5d66d600832b913b1d4a5a7af735