### PR TITLE
Refinar estilo de encabezados en la tabla

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,9 @@
   color-scheme: light;
   --sheet-border: #dadce0;
   --sheet-header-bg: #f8f9fa;
+  --table-header-bg: linear-gradient(180deg, rgba(26, 115, 232, 0.08) 0%, rgba(26, 115, 232, 0.02) 100%);
+  --table-header-text: #202124;
+  --table-header-border: rgba(26, 115, 232, 0.18);
   --sheet-background: #f1f3f4;
   --sheet-surface: #ffffff;
   --sheet-surface-alt: #f8f9fa;
@@ -42,6 +45,9 @@
   color-scheme: dark;
   --sheet-border: #3c4043;
   --sheet-header-bg: #2a2d31;
+  --table-header-bg: linear-gradient(180deg, rgba(138, 180, 248, 0.28) 0%, rgba(138, 180, 248, 0.1) 100%);
+  --table-header-text: #e8eaed;
+  --table-header-border: rgba(138, 180, 248, 0.3);
   --sheet-background: #121212;
   --sheet-surface: #1f1f23;
   --sheet-surface-alt: #2a2d31;
@@ -679,10 +685,16 @@ body {
 .sheet-table thead th {
   position: sticky;
   top: 0;
-  background: var(--sheet-header-bg);
+  background: var(--table-header-bg);
   font-weight: 600;
-  color: var(--sheet-text);
+  color: var(--table-header-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  border-bottom: 1px solid var(--table-header-border);
+  box-shadow: inset 0 -1px 0 var(--table-header-border);
   z-index: 2;
+  backdrop-filter: blur(4px);
 }
 
 .sheet-table tbody tr:nth-child(even) td {


### PR DESCRIPTION
## Summary
- agrega variables de tema específicas para el encabezado de la tabla en modos claro y oscuro
- resalta los encabezados con contraste, mayúsculas y borde inferior para diferenciarlos de los datos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd70b3d018832b8dd96e6a97541b62