### PR TITLE
Add status badges to estatus column

### DIFF
--- a/app.js
+++ b/app.js
@@ -1123,6 +1123,19 @@
       return String(value).trim();
     }
 
+    function getStatusBadgeSlug(value) {
+      const normalized = normalizeStatusValue(value);
+      if (!normalized) {
+        return '';
+      }
+      return normalized
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    }
+
     function isSameStatus(a, b) {
       return normalizeStatusValue(a).toLowerCase() === normalizeStatusValue(b).toLowerCase();
     }
@@ -2096,6 +2109,7 @@
           const normalizedHeader = headerLabel == null ? '' : String(headerLabel).trim().toLowerCase();
           const isTripColumn = normalizedHeader === 'trip';
           const isTrackingColumn = normalizedHeader === 'tracking';
+          const isStatusColumn = normalizedHeader === 'estatus';
           if (isDateHeader(headerLabel) && value !== '') {
             const formatted = fmtDate(value, state.locale);
             value = formatted || value;
@@ -2130,6 +2144,21 @@
               link.rel = 'noopener noreferrer';
               link.className = 'table-link';
               td.appendChild(link);
+            } else {
+              td.classList.add('is-empty');
+              td.textContent = '';
+            }
+          } else if (isStatusColumn) {
+            const normalizedStatus = normalizeStatusValue(value);
+            if (normalizedStatus) {
+              const badge = doc.createElement('span');
+              const slug = getStatusBadgeSlug(normalizedStatus);
+              badge.className = 'status-badge';
+              if (slug) {
+                badge.classList.add('status-badge--' + slug);
+              }
+              badge.textContent = normalizedStatus;
+              td.appendChild(badge);
             } else {
               td.classList.add('is-empty');
               td.textContent = '';

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,18 @@
   --accent-shadow: rgba(26, 115, 232, 0.25);
   --danger: #d93025;
   --success: #188038;
+  --status-default-bg: rgba(95, 99, 104, 0.12);
+  --status-default-text: #3c4043;
+  --status-in-transit-bg: rgba(26, 115, 232, 0.16);
+  --status-in-transit-text: #174ea6;
+  --status-delivered-bg: rgba(24, 128, 56, 0.14);
+  --status-delivered-text: #0b5e2c;
+  --status-pending-bg: rgba(251, 188, 5, 0.2);
+  --status-pending-text: #7c4a00;
+  --status-cancelled-bg: rgba(217, 48, 37, 0.2);
+  --status-cancelled-text: #8a1312;
+  --status-delayed-bg: rgba(240, 124, 0, 0.18);
+  --status-delayed-text: #7a2d00;
   --button-background: #ffffff;
   --button-background-hover: rgba(26, 115, 232, 0.08);
   --button-primary-text: #ffffff;
@@ -65,6 +77,18 @@
   --accent-shadow: rgba(45, 110, 194, 0.45);
   --danger: #ff9f95;
   --success: #7dd5a2;
+  --status-default-bg: rgba(124, 154, 197, 0.22);
+  --status-default-text: #e0ebff;
+  --status-in-transit-bg: rgba(98, 176, 255, 0.3);
+  --status-in-transit-text: #ecf6ff;
+  --status-delivered-bg: rgba(125, 213, 162, 0.32);
+  --status-delivered-text: #e7ffee;
+  --status-pending-bg: rgba(255, 204, 0, 0.28);
+  --status-pending-text: #fff1b3;
+  --status-cancelled-bg: rgba(255, 159, 149, 0.3);
+  --status-cancelled-text: #ffe1dd;
+  --status-delayed-bg: rgba(255, 183, 77, 0.3);
+  --status-delayed-text: #ffe8c5;
   --button-background: #172a47;
   --button-background-hover: rgba(98, 176, 255, 0.18);
   --button-primary-text: #f2f7ff;
@@ -742,6 +766,52 @@ body {
 
 .sheet-table tbody td.is-empty {
   color: var(--table-empty-color);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.125rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  background: var(--status-default-bg);
+  color: var(--status-default-text);
+  border: 1px solid transparent;
+  text-transform: none;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.status-badge--en-transito {
+  background: var(--status-in-transit-bg);
+  color: var(--status-in-transit-text);
+}
+
+.status-badge--entregado {
+  background: var(--status-delivered-bg);
+  color: var(--status-delivered-text);
+}
+
+.status-badge--pendiente,
+.status-badge--en-espera {
+  background: var(--status-pending-bg);
+  color: var(--status-pending-text);
+}
+
+.status-badge--cancelado,
+.status-badge--cancelada {
+  background: var(--status-cancelled-bg);
+  color: var(--status-cancelled-text);
+}
+
+.status-badge--demorado,
+.status-badge--retrasado {
+  background: var(--status-delayed-bg);
+  color: var(--status-delayed-text);
 }
 
 .sheet-table th.is-date,


### PR DESCRIPTION
## Summary
- render estatus cells as themed status badges using the normalized status value
- add helper to derive reusable CSS slugs from normalized statuses
- introduce light and dark theme styling for common status badge variants

## Testing
- node fmtDate.test.js
- node backend.test.js
- node bulkAddDuplicates.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cde5ba0c18832bb1b2c0b94fde0fcc