### PR TITLE
Add hover highlight styling for sheet table rows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -745,6 +745,10 @@ body {
   background: var(--sheet-surface);
 }
 
+.sheet-table tbody td {
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
 .sheet-table thead th {
   position: sticky;
   top: 0;
@@ -762,6 +766,17 @@ body {
 
 .sheet-table tbody tr:nth-child(even) td {
   background: var(--sheet-surface-muted);
+}
+
+.sheet-table tbody tr:hover td {
+  background: var(--accent-surface);
+  box-shadow: inset 0.25rem 0 0 var(--accent-border-weak);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sheet-table tbody td {
+    transition: none;
+  }
 }
 
 .sheet-table tbody td.is-empty {


### PR DESCRIPTION
## Summary
- add smooth background and accent edge transitions for sheet table body cells
- highlight hovered rows with the accent surface color for better readability
- disable the hover transition when users prefer reduced motion

## Testing
- no automated tests were run (not required for CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cde7018e4c832ba07ef566bec4b77a