### PR TITLE
Adjust dark theme sheet surfaces for clearer contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,15 +56,15 @@
 :root[data-theme='dark'] {
   color-scheme: dark;
   --sheet-border: #1b2a44;
-  --sheet-header-bg: #13213a;
+  --sheet-header-bg: #101d33;
   --table-header-bg: linear-gradient(180deg, rgba(103, 165, 241, 0.32) 0%, rgba(58, 109, 189, 0.18) 100%);
   --table-header-text: #e7f1ff;
   --table-header-border: rgba(91, 147, 226, 0.4);
-  --sheet-background: #070f1f;
-  --sheet-surface: #0d182c;
-  --sheet-surface-alt: #12213a;
-  --sheet-surface-muted: #152542;
-  --sheet-popover: #152542;
+  --sheet-background: #0a1526;
+  --sheet-surface: #11213a;
+  --sheet-surface-alt: #1a2e4d;
+  --sheet-surface-muted: #243a60;
+  --sheet-popover: #1e3356;
   --modal-surface: #162948;
   --sheet-text: #f2f7ff;
   --sheet-text-soft: #a7c4e8;


### PR DESCRIPTION
## Summary
- lighten the dark theme sheet background and surfaces to create a clearer gradient between layers
- update the dark header and popover colors to align with the refreshed palette

## Testing
- node - <<'NODE'
const colors = [
  ['background', '#0a1526'],
  ['surface', '#11213a'],
  ['alt', '#1a2e4d'],
  ['muted', '#243a60'],
];
const text = '#f2f7ff';
function luminance(hex) {
  const rgb = hex.replace('#','').match(/.{2}/g).map(x=>parseInt(x,16)/255).map(v=>{
    return v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055, 2.4);
  });
  return 0.2126*rgb[0] + 0.7152*rgb[1] + 0.0722*rgb[2];
}
function contrast(hex1, hex2) {
  const L1 = luminance(hex1);
  const L2 = luminance(hex2);
  const [light, dark] = L1 > L2 ? [L1, L2] : [L2, L1];
  return (light + 0.05) / (dark + 0.05);
}
for (const [name, color] of colors) {
  console.log(name, contrast(color, text).toFixed(2));
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cdeaed7b80832b871506e4ae69643c