### PR TITLE
Adjust button theming for neutral base and ghost secondary

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
           </label>
           <span class="theme-toggle__text" data-theme-label>Tema claro</span>
         </div>
-        <button type="button" class="button is-hidden" data-action="change-token">Cambiar token</button>
-        <button type="button" class="button" data-action="refresh">Actualizar</button>
+        <button type="button" class="button button--secondary is-hidden" data-action="change-token">Cambiar token</button>
+        <button type="button" class="button button--secondary" data-action="refresh">Actualizar</button>
         <button type="button" class="button button--primary" data-action="new-record">Nuevo registro</button>
         <button type="button" class="button button--secondary" data-action="logout">Cerrar sesión</button>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -261,15 +261,17 @@ body {
 }
 
 .button {
-  border: 1px solid var(--accent);
+  border: 1px solid var(--button-secondary-border);
   background: var(--button-background);
-  color: var(--accent);
+  color: var(--sheet-text);
   font-size: 0.9rem;
   font-weight: 500;
   border-radius: 8px;
   padding: 10px 18px;
   cursor: pointer;
-  transition: background var(--transition), color var(--transition), border-color var(--transition);
+  transition: background var(--transition), color var(--transition), border-color var(--transition),
+    box-shadow var(--transition);
+  box-shadow: none;
 }
 
 .button:focus {
@@ -278,27 +280,55 @@ body {
 }
 
 .button:hover {
-  background: var(--button-background-hover);
+  background: var(--sheet-surface-alt);
+  box-shadow: var(--shadow-sm);
 }
 
 .button:disabled {
+  background: var(--sheet-surface-muted);
+  color: var(--sheet-text-soft);
+  border-color: var(--button-secondary-border);
+  box-shadow: none;
   opacity: 0.6;
-  cursor: wait;
+  cursor: not-allowed;
 }
 
 .button--primary {
   background: var(--accent);
   color: var(--button-primary-text);
+  border-color: var(--accent);
 }
 
 .button--primary:hover {
   background: var(--accent-hover);
   color: var(--button-primary-text);
+  box-shadow: var(--shadow-sm);
+}
+
+.button--primary:disabled {
+  background: var(--accent);
+  color: var(--button-primary-text);
+  border-color: var(--accent);
 }
 
 .button--secondary {
+  background: transparent;
+  color: var(--sheet-text);
   border-color: var(--button-secondary-border);
+  box-shadow: none;
+}
+
+.button--secondary:hover {
+  background: transparent;
+  border-color: var(--accent-border-weak);
+  color: var(--sheet-text);
+  box-shadow: none;
+}
+
+.button--secondary:disabled {
+  background: transparent;
   color: var(--sheet-text-soft);
+  border-color: var(--button-secondary-border);
 }
 
 .sheet-app__footer-item--status {


### PR DESCRIPTION
## Summary
- update the base button style to use neutral theming and refined interaction states
- keep the primary modifier as the accent-filled CTA with consistent hover and disabled styling
- convert the secondary modifier to a ghost outline and apply it to non-CTA buttons in the toolbar

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdef2cb84c832ba695819c44fc8d77