### PR TITLE
Encapsular filtros en tarjetas

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,96 +43,104 @@
     <div class="sheet-grid">
       <div class="sheet-grid__views" data-view-menu role="toolbar" aria-label="Vistas de la tabla"></div>
       <div class="sheet-grid__filters" data-filter-panel>
-        <label class="sheet-grid__filter-field" for="filterSearch">
-          <span class="sheet-grid__filter-label">Buscar:</span>
-          <input
-            id="filterSearch"
-            type="search"
-            name="filterSearch"
-            placeholder="Trip, Caja o Referencia"
-            autocomplete="off"
-            spellcheck="false"
-            data-filter-search
-          />
-        </label>
-        <div class="sheet-grid__filter-field sheet-grid__filter-field--date" data-date-filter>
-          <span class="sheet-grid__filter-label">Fecha:</span>
-          <div class="date-filter">
-            <button type="button" class="date-filter__nav" data-action="date-prev" aria-label="Rango anterior">
-              <span aria-hidden="true">&#x2039;</span>
-            </button>
-            <button
-              type="button"
-              class="date-filter__toggle"
-              data-action="date-toggle"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-            >
-              <svg class="date-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path
-                  d="M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v11a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1Zm12 6H5v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1Z"
-                  fill="currentColor"
-                ></path>
-              </svg>
-              <span class="date-filter__label" data-date-label>Hoy</span>
-            </button>
-            <button type="button" class="date-filter__nav" data-action="date-next" aria-label="Rango siguiente">
-              <span aria-hidden="true">&#x203A;</span>
-            </button>
-          </div>
-          <div class="date-filter__popover" data-date-popover hidden>
-            <div class="date-filter__group">
-              <label>
-                <span>Desde</span>
-                <input type="date" data-date-start />
-              </label>
-              <label>
-                <span>Hasta</span>
-                <input type="date" data-date-end />
-              </label>
+        <div class="filter-card filter-card--search">
+          <label class="sheet-grid__filter-field" for="filterSearch">
+            <span class="sheet-grid__filter-label">Buscar:</span>
+            <input
+              id="filterSearch"
+              type="search"
+              name="filterSearch"
+              placeholder="Trip, Caja o Referencia"
+              autocomplete="off"
+              spellcheck="false"
+              data-filter-search
+            />
+          </label>
+        </div>
+        <div class="filter-card filter-card--date">
+          <div class="sheet-grid__filter-field sheet-grid__filter-field--date" data-date-filter>
+            <span class="sheet-grid__filter-label">Fecha:</span>
+            <div class="date-filter">
+              <button type="button" class="date-filter__nav" data-action="date-prev" aria-label="Rango anterior">
+                <span aria-hidden="true">&#x2039;</span>
+              </button>
+              <button
+                type="button"
+                class="date-filter__toggle"
+                data-action="date-toggle"
+                aria-haspopup="dialog"
+                aria-expanded="false"
+              >
+                <svg class="date-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path
+                    d="M7 2a1 1 0 0 0-1 1v1H5a3 3 0 0 0-3 3v11a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3h-1V3a1 1 0 1 0-2 0v1H8V3a1 1 0 0 0-1-1Zm12 6H5v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1Z"
+                    fill="currentColor"
+                  ></path>
+                </svg>
+                <span class="date-filter__label" data-date-label>Hoy</span>
+              </button>
+              <button type="button" class="date-filter__nav" data-action="date-next" aria-label="Rango siguiente">
+                <span aria-hidden="true">&#x203A;</span>
+              </button>
             </div>
-            <div class="date-filter__actions">
-              <button type="button" class="date-filter__clear" data-action="date-clear">Limpiar</button>
+            <div class="date-filter__popover" data-date-popover hidden>
+              <div class="date-filter__group">
+                <label>
+                  <span>Desde</span>
+                  <input type="date" data-date-start />
+                </label>
+                <label>
+                  <span>Hasta</span>
+                  <input type="date" data-date-end />
+                </label>
+              </div>
+              <div class="date-filter__actions">
+                <button type="button" class="date-filter__clear" data-action="date-clear">Limpiar</button>
+              </div>
             </div>
           </div>
         </div>
-        <div class="sheet-grid__filter-field sheet-grid__filter-field--status" data-status-filter>
-          <span class="sheet-grid__filter-label">Estatus:</span>
-          <div class="status-filter">
-            <button
-              type="button"
-              class="status-filter__toggle"
-              data-action="status-toggle"
-              aria-haspopup="listbox"
-              aria-expanded="false"
-            >
-              <span class="status-filter__label" data-status-label>Todos</span>
-              <svg class="status-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M7 10l5 5 5-5H7z" fill="currentColor"></path>
-              </svg>
-            </button>
-            <div class="status-filter__popover" data-status-popover hidden>
-              <ul class="status-filter__list" data-status-list role="listbox" aria-label="Opciones de estatus"></ul>
+        <div class="filter-card filter-card--status">
+          <div class="sheet-grid__filter-field sheet-grid__filter-field--status" data-status-filter>
+            <span class="sheet-grid__filter-label">Estatus:</span>
+            <div class="status-filter">
+              <button
+                type="button"
+                class="status-filter__toggle"
+                data-action="status-toggle"
+                aria-haspopup="listbox"
+                aria-expanded="false"
+              >
+                <span class="status-filter__label" data-status-label>Todos</span>
+                <svg class="status-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M7 10l5 5 5-5H7z" fill="currentColor"></path>
+                </svg>
+              </button>
+              <div class="status-filter__popover" data-status-popover hidden>
+                <ul class="status-filter__list" data-status-list role="listbox" aria-label="Opciones de estatus"></ul>
+              </div>
             </div>
           </div>
         </div>
-        <div class="sheet-grid__filter-field sheet-grid__filter-field--client" data-client-filter>
-          <span class="sheet-grid__filter-label">Cliente:</span>
-          <div class="client-filter">
-            <button
-              type="button"
-              class="client-filter__toggle"
-              data-action="client-toggle"
-              aria-haspopup="listbox"
-              aria-expanded="false"
-            >
-              <span class="client-filter__label" data-client-label>Todos</span>
-              <svg class="client-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M7 10l5 5 5-5H7z" fill="currentColor"></path>
-              </svg>
-            </button>
-            <div class="client-filter__popover" data-client-popover hidden>
-              <ul class="client-filter__list" data-client-list role="listbox" aria-label="Opciones de cliente"></ul>
+        <div class="filter-card filter-card--client">
+          <div class="sheet-grid__filter-field sheet-grid__filter-field--client" data-client-filter>
+            <span class="sheet-grid__filter-label">Cliente:</span>
+            <div class="client-filter">
+              <button
+                type="button"
+                class="client-filter__toggle"
+                data-action="client-toggle"
+                aria-haspopup="listbox"
+                aria-expanded="false"
+              >
+                <span class="client-filter__label" data-client-label>Todos</span>
+                <svg class="client-filter__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M7 10l5 5 5-5H7z" fill="currentColor"></path>
+                </svg>
+              </button>
+              <div class="client-filter__popover" data-client-popover hidden>
+                <ul class="client-filter__list" data-client-list role="listbox" aria-label="Opciones de cliente"></ul>
+              </div>
             </div>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -396,12 +396,54 @@ body {
 
 .sheet-grid__filters {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
+  align-items: stretch;
+  gap: 16px;
+  padding: 16px;
   border-bottom: 1px solid var(--sheet-border);
   background: var(--sheet-header-bg);
   flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.filter-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1 1 260px;
+  min-width: min(260px, 100%);
+  background: var(--sheet-surface);
+  border: 1px solid var(--sheet-border);
+  border-radius: calc(var(--radius) - 4px);
+  padding: 12px 16px;
+  box-shadow: var(--shadow-sm);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.filter-card--search {
+  flex-basis: 320px;
+  min-width: min(320px, 100%);
+}
+
+@media (max-width: 768px) {
+  .filter-card {
+    flex: 1 1 100%;
+    min-width: 100%;
+  }
+
+  .filter-card--search {
+    flex-basis: 100%;
+  }
+}
+
+.filter-card:focus-within {
+  border-color: var(--accent-border-weak);
+  box-shadow: 0 0 0 3px var(--button-focus-outline), var(--shadow-sm);
+}
+
+.filter-card > .sheet-grid__filter-field,
+.filter-card > label.sheet-grid__filter-field {
+  width: 100%;
+  max-width: 100%;
 }
 
 .sheet-grid__filter-field {
@@ -409,7 +451,7 @@ body {
   align-items: center;
   gap: 8px;
   width: 100%;
-  max-width: 360px;
+  max-width: 100%;
   font-size: 0.9rem;
   color: var(--sheet-text-soft);
 }


### PR DESCRIPTION
## Summary
- Agrupar los filtros de búsqueda, fecha, estatus y cliente dentro de tarjetas con la nueva clase `filter-card`.
- Añadir estilos de tarjeta y ajustes responsivos al panel `.sheet-grid__filters` para mejorar la presentación en pantallas estrechas.
- Afinar los estilos de los campos para conservar alineación y resaltar el foco, manteniendo el contraste y el flujo de tabulación.

## Testing
- No automated tests were run (not provided).


------
https://chatgpt.com/codex/tasks/task_e_68cdf0b3df10832b8e2c8615557b7170