### PR TITLE
Evitar saltos de línea en filas de la tabla

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -819,6 +819,7 @@ body {
 
 .sheet-table tbody td {
   transition: background var(--transition), box-shadow var(--transition);
+  white-space: nowrap;
 }
 
 .sheet-table thead th {


### PR DESCRIPTION
## Summary
- evitar que las celdas del cuerpo de la tabla envuelvan su contenido para que cada fila se muestre en una sola línea

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdf359785c832b822c5c21c26df613